### PR TITLE
make bucket mapping more flexible include necessary logging for EMS

### DIFF
--- a/daac/main.tf
+++ b/daac/main.tf
@@ -44,6 +44,12 @@ resource "aws_s3_bucket" "standard-bucket" {
   }
 }
 
+//For EMS reporting, buckets which are exposed by TEA need to have server access
+// logging enabled.  The Cumulus standard is for the logs to be added to the
+// "internal" bucket.  An acl is added to this bucket
+//  This is documented more fully in:
+//  https://nasa.github.io/cumulus/docs/deployment/server_access_logging
+
 resource "aws_s3_bucket" "internal-bucket" {
   bucket = "${local.prefix}-internal"
   lifecycle {
@@ -52,6 +58,7 @@ resource "aws_s3_bucket" "internal-bucket" {
   acl    = "log-delivery-write"
 }
 
+// protected buckets log to "internal"
 resource "aws_s3_bucket" "protected-bucket" {
   // protected buckets defined in variables.tf
   for_each = toset(local.protected_bucket_names)
@@ -65,6 +72,7 @@ resource "aws_s3_bucket" "protected-bucket" {
   }
 }
 
+// public buckets log to "internal"
 resource "aws_s3_bucket" "public-bucket" {
   // public buckets defined in variables.tf
   for_each = toset(local.public_bucket_names)

--- a/daac/main.tf
+++ b/daac/main.tf
@@ -13,14 +13,26 @@ provider "aws" {
 locals {
   prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
 
-  standard_bucket_names = [for n in var.standard_bucket_names : "${local.prefix}-${n}"]
-  workflow_bucket_names = [for n in var.workflow_bucket_names : "${local.prefix}-${n}"]
+  standard_bucket_names  = [for n in var.standard_bucket_names  : "${local.prefix}-${n}"]
+  protected_bucket_names = [for n in var.protected_bucket_names : "${local.prefix}-${n}"]
+  public_bucket_names    = [for n in var.public_bucket_names    : "${local.prefix}-${n}"]
+  workflow_bucket_names  = [for n in var.workflow_bucket_names  : "${local.prefix}-${n}"]
 
-  standard_bucket_map = { for n in var.standard_bucket_names : n => { name = "${local.prefix}-${n}", type = n } }
-  workflow_bucket_map = { for n in var.workflow_bucket_names : n => { name = "${local.prefix}-${n}", type = "workflow" } }
+  standard_bucket_map  = { for n in var.standard_bucket_names  : n => { name = "${local.prefix}-${n}", type = n } }
+  protected_bucket_map = { for n in var.protected_bucket_names : n => { name = "${local.prefix}-${n}", type = "protected" } }
+  public_bucket_map    = { for n in var.public_bucket_names    : n => { name = "${local.prefix}-${n}", type = "public" } }
+  workflow_bucket_map  = { for n in var.workflow_bucket_names  : n => { name = "${local.prefix}-${n}", type = "workflow" } }
+  internal_bucket_map  = {
+    internal = {
+      name = "${local.prefix}-internal"
+      type = "internal"
+    }
+  }
 
   // creates a TEA style bucket map, is outputted via outputs.tf
-  bucket_map = merge(local.standard_bucket_map, local.workflow_bucket_map)
+  bucket_map = merge(local.standard_bucket_map, local.internal_bucket_map,
+                     local.protected_bucket_map, local.public_bucket_map,
+                     local.workflow_bucket_map)
 }
 
 resource "aws_s3_bucket" "standard-bucket" {
@@ -29,6 +41,40 @@ resource "aws_s3_bucket" "standard-bucket" {
   bucket = each.key
   lifecycle {
     prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket" "internal-bucket" {
+  bucket = "${local.prefix}-internal"
+  lifecycle {
+    prevent_destroy = true
+  }
+  acl    = "log-delivery-write"
+}
+
+resource "aws_s3_bucket" "protected-bucket" {
+  // protected buckets defined in variables.tf
+  for_each = toset(local.protected_bucket_names)
+  bucket = each.key
+  lifecycle {
+    prevent_destroy = true
+  }
+  logging {
+    target_bucket = "${local.prefix}-internal"
+    target_prefix = "${local.prefix}/ems-distribution/s3-server-access-logs/"
+  }
+}
+
+resource "aws_s3_bucket" "public-bucket" {
+  // public buckets defined in variables.tf
+  for_each = toset(local.public_bucket_names)
+  bucket = each.key
+  lifecycle {
+    prevent_destroy = true
+  }
+  logging {
+    target_bucket = "${local.prefix}-internal"
+    target_prefix = "${local.prefix}/ems-distribution/s3-server-access-logs/"
   }
 }
 

--- a/daac/terraform.tfvars
+++ b/daac/terraform.tfvars
@@ -1,4 +1,17 @@
 cma_version = "v1.2.0"
+
+# default bucket lists are:
+# standard_bucket_names = ["private"]
+# protected_bucket_names = ["protected"]
+# public_bucket_names = ["public"]
+
+# if you want to overide the default standard, protected or public bucket lists
+# you can do it here
+standard_bucket_names = ["private", "dashboard"]
+protected_bucket_names = ["protected", "protected-1"]
+public_bucket_names = ["public", "public-1"]
+
+# example workflow bucket list
 workflow_bucket_names = [
   "acme-landing",
   "acme-products",

--- a/daac/variables.tf
+++ b/daac/variables.tf
@@ -13,7 +13,17 @@ variable "cma_version" {
 
 variable "standard_bucket_names" {
   type = list(string)
-  default = ["internal", "private", "protected", "public"]
+  default = ["private"]
+}
+
+variable "protected_bucket_names" {
+  type = list(string)
+  default = ["protected"]
+}
+
+variable "public_bucket_names" {
+  type = list(string)
+  default = ["public"]
 }
 
 variable "workflow_bucket_names" {


### PR DESCRIPTION
This change attempts to resolve issue #14  and #15.  To do that, it separates out standard, protected and public bucket lists.  It also hard codes in the internal bucket.  It enables the necessary logging for EMS reporting per these Cumulus instructions.

https://nasa.github.io/cumulus/docs/deployment/server_access_logging

One problem introduced by this code occurs during the first `make daac`, Terraform wants to delete/recreate the internal/protected/public buckets.  The  `lifecycle {prevent_destroy = true}` on the buckets prevents that.  

If a daac wants to retain the contents of those buckets I think they could sync their contents to other buckets, then empty and destroy them manually.  `make daac` will then recreate them and they can sync back.  

If the contents can be destroyed, the daac will at least need to rerun `make data-persistence and `make cumulus` to recreate the contents of the `internal` bucket.

Any other ideas how we could resolve the issues without forcing the recreation of the buckets?

