### PR TITLE
CIRRUS-DAAC: Replaced interpolation expressions with HCL2 expressions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM amazonlinux:2
 #   * Application Python dependencies
 
 ENV NODE_VERSION "12.x"
-ENV TERRAFORM_VERSION "0.14.0"
+ENV TERRAFORM_VERSION "0.12.18"
 
 # Add NodeJS and Yarn repos & update package index
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM amazonlinux:2
 #   * Application Python dependencies
 
 ENV NODE_VERSION "12.x"
-ENV TERRAFORM_VERSION "0.12.18"
+ENV TERRAFORM_VERSION "0.14.0"
 
 # Add NodeJS and Yarn repos & update package index
 RUN \

--- a/daac/main.tf
+++ b/daac/main.tf
@@ -159,7 +159,7 @@ resource "aws_s3_bucket" "artifacts-bucket" {
 
 resource "null_resource" "CMA_release" {
   triggers = {
-    always_run = "${timestamp()}"
+    always_run = timestamp()
   }
   provisioner "local-exec" {
     command = "mkdir -p tmp && curl -L -o tmp/cumulus-message-adapter.zip https://github.com/nasa/cumulus-message-adapter/releases/download/${var.cma_version}/cumulus-message-adapter.zip"

--- a/daac/outputs.tf
+++ b/daac/outputs.tf
@@ -1,5 +1,5 @@
 output "cma_layer_arn" {
-  value = "${aws_lambda_layer_version.cma_layer.arn}"
+  value = aws_lambda_layer_version.cma_layer.arn
 }
 
 output "bucket_map" {

--- a/daac/s3-replicator.tf
+++ b/daac/s3-replicator.tf
@@ -20,8 +20,8 @@ locals {
 
   replicator_bucket        = "${local.prefix}-internal"
   replicator_prefix        = "input/s3_access/${var.DEPLOY_NAME}${var.MATURITY}"
-  replicator_target_bucket = "${var.s3_replicator_target_bucket == null ? local.replicator_bucket : var.s3_replicator_target_bucket}"
-  replicator_target_prefix = "${var.s3_replicator_target_prefix == null ? local.replicator_prefix : var.s3_replicator_target_prefix}"
+  replicator_target_bucket = var.s3_replicator_target_bucket == null ? local.replicator_bucket : var.s3_replicator_target_bucket
+  replicator_target_prefix = var.s3_replicator_target_prefix == null ? local.replicator_prefix : var.s3_replicator_target_prefix
 
 }
 
@@ -29,11 +29,11 @@ module "s3-replicator" {
 
   source = "https://github.com/nasa/cumulus/releases/download/v4.0.0/terraform-aws-cumulus-s3-replicator.zip"
 
-  prefix               = "${local.prefix}"
+  prefix               = local.prefix
   vpc_id               = data.aws_vpc.application_vpcs.id
   subnet_ids           = data.aws_subnet_ids.subnet_ids.ids
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/NGAPShRoleBoundary"
-  tags                 = { Deployment = "${local.prefix}" }
+  tags                 = { Deployment = local.prefix }
   source_bucket        = "${local.prefix}-internal"
   source_prefix        = "${local.prefix}/ems-distribution/s3-server-access-logs"
   target_bucket        = local.replicator_target_bucket

--- a/workflows/main.tf
+++ b/workflows/main.tf
@@ -38,7 +38,7 @@ locals {
   cumulus_remote_state_config = {
     bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
     key    = "cumulus/terraform.tfstate"
-    region = "${data.aws_region.current.name}"
+    region = data.aws_region.current.name
   }
 }
 
@@ -47,7 +47,7 @@ data "aws_region" "current" {}
 
 data "terraform_remote_state" "cumulus" {
   backend   = "s3"
-  workspace = "${var.DEPLOY_NAME}"
+  workspace = var.DEPLOY_NAME
   config    = local.cumulus_remote_state_config
 }
 


### PR DESCRIPTION
This should remove the following warning:
```Bash
Warning: Interpolation-only expressions are deprecated

  on common.tf line 35, in locals:
  35:     region = "${data.aws_region.current.name}"
```