### PR TITLE
Add new "partner" bucket type for external/non-created buckets

### DIFF
--- a/daac/main.tf
+++ b/daac/main.tf
@@ -24,11 +24,13 @@ locals {
   protected_bucket_names = [for n in var.protected_bucket_names : "${local.prefix}-${n}"]
   public_bucket_names    = [for n in var.public_bucket_names : "${local.prefix}-${n}"]
   workflow_bucket_names  = [for n in var.workflow_bucket_names : "${local.prefix}-${n}"]
+  partner_bucket_names  = [for n in var.partner_bucket_names : "${n}"] 
 
   standard_bucket_map  = { for n in var.standard_bucket_names : n => { name = "${local.prefix}-${n}", type = n } }
   protected_bucket_map = { for n in var.protected_bucket_names : n => { name = "${local.prefix}-${n}", type = "protected" } }
   public_bucket_map    = { for n in var.public_bucket_names : n => { name = "${local.prefix}-${n}", type = "public" } }
   workflow_bucket_map  = { for n in var.workflow_bucket_names : n => { name = "${local.prefix}-${n}", type = "workflow" } }
+  partner_bucket_map  = { for n in var.partner_bucket_names : n => { name = "${n}", type = "partner" } }
   internal_bucket_map = {
     internal = {
       name = "${local.prefix}-internal"

--- a/daac/terraform.tfvars
+++ b/daac/terraform.tfvars
@@ -17,3 +17,7 @@ workflow_bucket_names = [
   "acme-products",
   "acme-browse"
 ]
+
+# Example of buckets we need to access, but won't create.
+# These ARE NOT prefixed
+partner_bucket_names = ["partner-collab-s3-bucket"]

--- a/daac/variables.tf
+++ b/daac/variables.tf
@@ -31,6 +31,11 @@ variable "workflow_bucket_names" {
   default = []
 }
 
+variable "partner_bucket_names" {
+  type = list(string)
+  default = []
+}
+
 variable "s3_replicator_target_bucket" {
   type = string
   default = null

--- a/daac/variables/dev.tfvars
+++ b/daac/variables/dev.tfvars
@@ -1,5 +1,6 @@
 #workflow_bucket_names = []
 #standard_bucket_names = ["private", "dashboard"]
+#partner_bucket_names = ["non-prefixed-external-bucket"]
 
 #s3_replicator_target_bucket = "metrics target bucket name"
 #s3_replicator_target_prefix = "metrics target prefix name"


### PR DESCRIPTION
This allows for whitelisting buckets that we need to access, but we don't create (ie are in another account, or shared across maturities)