### PR TITLE
GitHub Actions: run just for master and PRs, only on Linux

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: lint
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:
@@ -9,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
NSIDC recently got an alert that we were at 75% of our GitHub Action minutes limit for the month, and then we found that Windows build minutes count for 2x, and Mac build minutes count for 10x. The lint config added https://github.com/asfadmin/CIRRUS-DAAC/pull/60 was copy-pasted from a template that ran on Linux, Windows, and Mac, but running on Linux should be all that's necessary.

Additionally, the linting doesn't need to run on tags or on open branches that are not in pull requests, so the configuration is set to run only for the `master` branch and pull requests.

See also https://github.com/asfadmin/CIRRUS-core/pull/123