### PR TITLE
Bump engine version to latest version of 10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+## Unreleased
+
+* Bump RDS engine version to 10.18
+
 ## v11.1.0.1
 
 * CIRRUS-core: added scripts for Cumulus v11.0.0 post-deployment notes

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -34,7 +34,7 @@ variable "snapshot_identifier" {
 variable "engine_version" {
   description = "Postgres engine version for Serverless cluster"
   type        = string
-  default     = "10.14"
+  default     = "10.18"
 }
 
 ### Required for user/database provisioning


### PR DESCRIPTION
Deploy fails because AWS automatically upgrades to the latest version and doesn't let terraform perform a downgrade:

```
Error: Failed to modify RDS Cluster (sds-n-cumulus-dev-rds-cluster): InvalidParameterCombination: Cannot find upgrade target from 10.serverless_18 with requested version 10.14 for serverless engine mode.
	status code: 400, request id: c21bf34b-704d-491a-9474-2f730e5079ef
```