### PR TITLE
Use job name as container name in Jenkins

### DIFF
--- a/daac/main.tf
+++ b/daac/main.tf
@@ -34,13 +34,13 @@ locals {
   protected_bucket_names = [for n in var.protected_bucket_names : "${local.prefix}-${n}"]
   public_bucket_names    = [for n in var.public_bucket_names : "${local.prefix}-${n}"]
   workflow_bucket_names  = [for n in var.workflow_bucket_names : "${local.prefix}-${n}"]
-  partner_bucket_names   = [for n in var.partner_bucket_names : "${n}"]
+  partner_bucket_names   = [for n in var.partner_bucket_names : n]
 
   standard_bucket_map  = { for n in var.standard_bucket_names : n => { name = "${local.prefix}-${n}", type = n } }
   protected_bucket_map = { for n in var.protected_bucket_names : n => { name = "${local.prefix}-${n}", type = "protected" } }
   public_bucket_map    = { for n in var.public_bucket_names : n => { name = "${local.prefix}-${n}", type = "public" } }
   workflow_bucket_map  = { for n in var.workflow_bucket_names : n => { name = "${local.prefix}-${n}", type = "workflow" } }
-  partner_bucket_map   = { for n in var.partner_bucket_names : n => { name = "${n}", type = "partner" } }
+  partner_bucket_map   = { for n in var.partner_bucket_names : n => { name = n, type = "partner" } }
   internal_bucket_map = {
     internal = {
       name = "${local.prefix}-internal"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -179,7 +179,8 @@ def deploy(params) {
     "AWS_REGION=${params.AWS_REGION}",
     "MATURITY=${params.MATURITY}",
     "CONTAINER_TAG=${params.CONTAINER_TAG}",
-    "MAKE_TARGET=${params.MAKE_TARGET}"
+    "MAKE_TARGET=${params.MAKE_TARGET}",
+    "CONTAINER_NAME_PREFIX=${env.JOB_NAME.replaceAll('/', '-')}"
   ]) {
     withCredentials([
       [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: params.AWS_CREDS],
@@ -208,7 +209,7 @@ def deploy(params) {
                               --env TF_VAR_db_admin_password="$DB_CREDS_PSW" \
                               -v "$WORKSPACE/CIRRUS-core":/CIRRUS-core \
                               -v "$WORKSPACE":/CIRRUS-DAAC \
-                              --name=cirrus-core \
+                              --name=$CONTAINER_NAME_PREFIX-cirrus-core \
                               cirrus-core:$CONTAINER_TAG \
                               /bin/bash -c "make $MAKE_TARGET"
       '''


### PR DESCRIPTION
Each running container needs to have a unique name, so using the same hardcoded name `cirrus-core` for every pipeline would prevent us from running multiple concurrent builds. I decided to go with the job name, and not include the build id, so that if the container gets stuck, we will be notified by subsequent builds erroring out instead of the stuck container just being forgotten about.