### PR TITLE
Only run git pull if CORE_REF references an actual branch

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -42,8 +42,9 @@ pipeline {
           git checkout ${params.CORE_REF}
           git submodule update --init --recursive
           # If working in a branch, we need to be sure to `git pull` new changes
-          if [ `git show -s --pretty=%d HEAD | grep -c 'HEAD, tag'` -gt 0 ]; then
-            echo 'Tag is up-to-date'; else git pull
+          cat .git/HEAD | grep -q "ref: refs/heads"
+          if [ \$? -eq 0 ]; then
+              git pull
           fi
           cd ..
           tree


### PR DESCRIPTION
Right now these commands will fail when encountering a commit id, however, we want to be able to pin to a commit id to prevent upstream changes from breaking our builds. This should allow all types of refs to work correctly.