### PR TITLE
upgrade Cumulus to v14.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ to match those in the underlying Cumulus modules.
 [Cumulus Dashboard v12.0.0](https://github.com/nasa/cumulus-dashboard/releases/tag/v12.0.0)
 * Also, any ECS tasks are required to use the `cumuluss/cumulus-ecs-task:1.8.0`
 docker image.  This requirement is listed in the
-[Cumulus v11.1.8](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
+[Cumulus v11.1.8](https://github.com/nasa/Cumulus/releases/tag/v11.1.8)
 breaking changes section.
 
 ## v13.3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 ## v14.1.0.0
 * Upgrade to [Cumulus v14.1.0](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
 * Bump RDS engine version to 11.13
-* Exposes the new `cloudwatch_log_retention_periods` as mentioned in the release
-notes in case a DAAC wants to modify the retention of any CloudWatch log groups.
-* updated the terraform `aws` provider in the `daac` and `workflows` modules
+* Updated the terraform `aws` provider in the `daac` and `workflows` modules
 to match those in the underlying Cumulus modules.
 * **Reminder** - this version requires
 [Cumulus Dashboard v12.0.0](https://github.com/nasa/cumulus-dashboard/releases/tag/v12.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 
 # CHANGELOG
 
-## Unreleased
+## v14.1.0.0
+* Upgrade to [Cumulus v14.1.0](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
 * Bump RDS engine version to 11.13
+* Exposes the new `cloudwatch_log_retention_periods` as mentioned in the release
+notes in case a DAAC wants to modify the retention of any CloudWatch log groups.
+* updated the terraform `aws` provider in the `daac` and `workflows` modules
+to match those in the underlying Cumulus modules.
+* **Reminder** - this version requires
+[Cumulus Dashboard v12.0.0](https://github.com/nasa/cumulus-dashboard/releases/tag/v12.0.0)
+* Also, any ECS tasks are required to use the `cumuluss/cumulus-ecs-task:1.8.0`
+docker image.  This requirement is listed in the
+[Cumulus v11.1.8](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
+breaking changes section.
 
 ## v13.3.2.0
 

--- a/daac/main.tf
+++ b/daac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.73.0"
+      version = "~> 3.0,!= 3.14.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/daac/s3-replicator.tf
+++ b/daac/s3-replicator.tf
@@ -27,7 +27,7 @@ locals {
 
 module "s3-replicator" {
 
-  source = "https://github.com/nasa/cumulus/releases/download/v13.3.2/terraform-aws-cumulus-s3-replicator.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus-s3-replicator.zip"
 
   prefix               = local.prefix
   vpc_id               = data.aws_vpc.application_vpcs.id

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -47,7 +47,7 @@ resource "random_string" "user_db_pass" {
 }
 
 module "rds_cluster" {
-  source                   = "https://github.com/nasa/cumulus/releases/download/v13.3.2/terraform-aws-cumulus-rds.zip"
+  source                   = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus-rds.zip"
   db_admin_username        = var.db_admin_username
   db_admin_password        = var.db_admin_password == "" ? random_string.admin_db_pass.result : var.db_admin_password
   region                   = data.aws_region.current.name

--- a/workflows/dev-requirements.txt
+++ b/workflows/dev-requirements.txt
@@ -1,5 +1,5 @@
 flake8~=3.7
-ipython~=7.9
+ipython~=8.10
 jedi~=0.15.0
 black~=19.10b0
 pytest~=5.3

--- a/workflows/main.tf
+++ b/workflows/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.70.0"
+      version = "~> 3.0,!= 3.14.0"
     }
     null = {
       source  = "hashicorp/null"
@@ -21,7 +21,7 @@ provider "aws" {
 
 module "acme_workflow" {
 
-  source = "https://github.com/nasa/cumulus/releases/download/v13.3.2/terraform-aws-cumulus-workflow.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus-workflow.zip"
 
   prefix          = local.prefix
   name            = "ACMEWorkflow"

--- a/workflows/variables.tf
+++ b/workflows/variables.tf
@@ -1,14 +1,20 @@
 variable "DEPLOY_NAME" {
-  type = string
+  type    = string
   default = "daac"
 }
 
 variable "MATURITY" {
-  type = string
+  type    = string
   default = "dev"
 }
 
 variable "DIST_DIR" {
-  type = string
+  type    = string
   default = "../dist"
+}
+
+variable "cloudwatch_log_retention_periods" {
+  type        = map(number)
+  description = "number of days logs will be retained for the respective cloudwatch log group, in the form of <module>_<cloudwatch_log_group_name>_log_retention"
+  default     = {}
 }

--- a/workflows/variables.tf
+++ b/workflows/variables.tf
@@ -12,9 +12,3 @@ variable "DIST_DIR" {
   type    = string
   default = "../dist"
 }
-
-variable "cloudwatch_log_retention_periods" {
-  type        = map(number)
-  description = "number of days logs will be retained for the respective cloudwatch log group, in the form of <module>_<cloudwatch_log_group_name>_log_retention"
-  default     = {}
-}


### PR DESCRIPTION
## v14.1.0.0
* Upgrade to [Cumulus v14.1.0](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
* Bump RDS engine version to 11.13
* Exposes the new `cloudwatch_log_retention_periods` as mentioned in the release notes in case a DAAC wants to modify the retention of any CloudWatch log groups.
* updated the terraform `aws` provider in the `daac` and `workflows` modules to match those in the underlying Cumulus modules.
* **Reminder** - this version requires [Cumulus Dashboard v12.0.0](https://github.com/nasa/cumulus-dashboard/releases/tag/v12.0.0)
* Also, any ECS tasks are required to use the `cumuluss/cumulus-ecs-task:1.8.0` docker image.  This requirement is listed in the [Cumulus v11.1.8](https://github.com/nasa/Cumulus/releases/tag/v14.1.0) breaking changes section.