### PR TITLE
upgrade Cumulus to v15.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 
 # CHANGELOG
 
+## v15.0.3.0
+
+* Upgrade to [Cumulus v15.0.3](https://github.com/nasa/Cumulus/releases/tag/v15.0.3)
+* Per [Cumulus v15.0.2](https://github.com/nasa/Cumulus/releases/tag/v15.0.2)
+release notes, the new `default_log_retention_days` variable has been exposed in
+the Cumulus module to allow daac customization,  default is 30 days (the release
+notes name it incorrectly)
+* Per [Cumulus v15.0.0](https://github.com/nasa/Cumulus/releases/tag/v15.0.0)
+release notes, all ECS tasks should be upgraded to use the `1.9.0` image
+* Upgraded the terraform aws version to `>= 3.75.2` to support `nodejs16.x` Lambdas
+
 ## v14.1.0.0
 * Upgrade to [Cumulus v14.1.0](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
 * Bump RDS engine version to 11.13

--- a/cumulus/provider.tf
+++ b/cumulus/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.70.0"
+      version = ">= 3.75.2"
     }
     null = {
       source  = "hashicorp/null"

--- a/daac/main.tf
+++ b/daac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0,!= 3.14.0"
+      version = ">= 3.75.2"
     }
     null = {
       source  = "hashicorp/null"

--- a/daac/s3-replicator.tf
+++ b/daac/s3-replicator.tf
@@ -27,7 +27,7 @@ locals {
 
 module "s3-replicator" {
 
-  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus-s3-replicator.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v15.0.3/terraform-aws-cumulus-s3-replicator.zip"
 
   prefix               = local.prefix
   vpc_id               = data.aws_vpc.application_vpcs.id

--- a/dashboard/main.tf
+++ b/dashboard/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    aws  = "~> 2.46.0"
+    version = ">= 3.75.2"
     null = "~> 2.1.0"
   }
   backend "s3" {

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.14.1"
+      version = ">= 3.75.2"
     }
 
     random = {
@@ -47,7 +47,7 @@ resource "random_string" "user_db_pass" {
 }
 
 module "rds_cluster" {
-  source                   = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus-rds.zip"
+  source                   = "https://github.com/nasa/cumulus/releases/download/v15.0.3/terraform-aws-cumulus-rds.zip"
   db_admin_username        = var.db_admin_username
   db_admin_password        = var.db_admin_password == "" ? random_string.admin_db_pass.result : var.db_admin_password
   region                   = data.aws_region.current.name

--- a/workflows/main.tf
+++ b/workflows/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0,!= 3.14.0"
+      version = ">= 3.75.2"
     }
     null = {
       source  = "hashicorp/null"
@@ -21,7 +21,7 @@ provider "aws" {
 
 module "acme_workflow" {
 
-  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus-workflow.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v15.0.3/terraform-aws-cumulus-workflow.zip"
 
   prefix          = local.prefix
   name            = "ACMEWorkflow"


### PR DESCRIPTION
* Upgrade to [Cumulus v15.0.3](https://github.com/nasa/Cumulus/releases/tag/v15.0.3)
* Per [Cumulus v15.0.2](https://github.com/nasa/Cumulus/releases/tag/v15.0.2) release notes, the new `default_log_retention_days` variable has been exposed in the Cumulus module to allow daac customization,  default is 30 days (the release notes name it incorrectly)
* Per [Cumulus v15.0.0](https://github.com/nasa/Cumulus/releases/tag/v15.0.0) release notes, all ECS tasks should be upgraded to use the `1.9.0` image
* Upgraded the terraform aws version to `>= 3.75.2` to support `nodejs16.x` Lambdas
