### PR TITLE
Add distribution bucket policy resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,12 @@
 
 # CHANGELOG
 
-## Unreleased
-
-* Add terraform resources to create bucket policies allowing CloudFront OAI's
-read access to distribution buckets.
-
 ## v17.0.0.0
 * Upgrade to [Cumulus v17.0.0](https://github.com/nasa/cumulus/releases/tag/v17.0.0)
 * Upgrade terraform modules to use AWS provider version 5.0
 * Remove data-migration1 from repo
+* Add terraform resources to create bucket policies allowing CloudFront OAI's
+read access to distribution buckets.
 
 ## v16.0.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # CHANGELOG
 
+## Unreleased
+
+* Add terraform resources to create bucket policies allowing CloudFront OAI's
+read access to distribution buckets.
 
 ## v17.0.0.0
 * Upgrade to [Cumulus v17.0.0](https://github.com/nasa/cumulus/releases/tag/v17.0.0)

--- a/daac/distribution_bucket_policy.tf
+++ b/daac/distribution_bucket_policy.tf
@@ -1,0 +1,41 @@
+data "aws_cloudfront_origin_access_identity" "distribution_cloudfront_oai" {
+  for_each = toset(values(var.distribution_bucket_oais))
+
+  id = each.key
+}
+
+data "aws_iam_policy_document" "distribution_bucket_policy_document" {
+  for_each = var.distribution_bucket_oais
+
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${local.prefix}-${each.key}/*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        data.aws_cloudfront_origin_access_identity.distribution_cloudfront_oai[each.value].iam_arn
+      ]
+    }
+  }
+
+  # Need ListBucket permissions so that missing keys will return 404 errors instead of 403
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${local.prefix}-${each.key}"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        data.aws_cloudfront_origin_access_identity.distribution_cloudfront_oai[each.value].iam_arn
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "distribution_bucket_policy" {
+  for_each = var.distribution_bucket_oais
+
+  bucket = "${local.prefix}-${each.key}"
+  policy = try(data.aws_iam_policy_document.distribution_bucket_policy_document[each.key].json, null)
+}

--- a/daac/variables.tf
+++ b/daac/variables.tf
@@ -36,6 +36,11 @@ variable "partner_bucket_names" {
   default = []
 }
 
+variable "distribution_bucket_oais" {
+  type    = map(any)
+  default = {}
+}
+
 variable "s3_replicator_target_bucket" {
   type    = string
   default = null


### PR DESCRIPTION
When setting up TEA behind a CloudFront distribution, any buckets that you will be distributing data from need to have a bucket policy that allows the CloudFront OAI to read the data. These bucket policies may be expanded in the future or maybe left to be expanded in the downstream forks.