### PR TITLE
Add orca/orca_recovery_workflow modules, update docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,158 @@ destroy-rds: rds-init
 				-auto-approve"
 	eval $$TF_CMD
 
+orca_recovery_workflow: orca_recovery_workflow-init
+	$(banner)
+	cd $@
+	if [ -f "secrets/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export SECRETS_OPT="-var-file=secrets/${MATURITY}.tfvars"
+		echo "Found maturity-specific secrets: $$SECRETS_OPT"
+		echo "***************************************************************"
+	fi
+	if [ -f "variables/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export VARIABLES_OPT="-var-file=variables/${MATURITY}.tfvars"
+		echo "Found maturity-specific variables: $$VARIABLES_OPT"
+		echo "***************************************************************"
+	fi
+	terraform apply \
+		$$SECRETS_OPT \
+		$$VARIABLES_OPT \
+		-input=false \
+		-auto-approve \
+		-no-color
+
+
+plan-orca_recovery_workflow: orca_recovery_workflow-init
+	$(banner)
+	cd orca_recovery_workflow
+	if [ -f "secrets/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export SECRETS_OPT="-var-file=secrets/${MATURITY}.tfvars"
+		echo "Found maturity-specific secrets: $$SECRETS_OPT"
+		echo "***************************************************************"
+	fi
+	if [ -f "variables/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export VARIABLES_OPT="-var-file=variables/${MATURITY}.tfvars"
+		echo "Found maturity-specific variables: $$VARIABLES_OPT"
+		echo "***************************************************************"
+	fi
+	terraform plan \
+		$$SECRETS_OPT \
+		$$VARIABLES_OPT \
+		-input=false \
+		-no-color
+
+
+destroy-orca_recovery_workflow: orca_recovery_workflow-init
+	$(banner)
+	cd orca_recovery_workflow
+	if [ -f "secrets/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export SECRETS_OPT="-var-file=secrets/${MATURITY}.tfvars"
+		echo "Found maturity-specific secrets: $$SECRETS_OPT"
+		echo "***************************************************************"
+	fi
+	if [ -f "variables/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export VARIABLES_OPT="-var-file=variables/${MATURITY}.tfvars"
+		echo "Found maturity-specific variables: $$VARIABLES_OPT"
+		echo "***************************************************************"
+	fi
+	terraform destroy \
+		$$SECRETS_OPT \
+		$$VARIABLES_OPT \
+		-input=false \
+		-auto-approve \
+		-no-color
+
+
+
+# ---------------------------
+orca: orca-init
+	$(banner)
+	cd $@
+	if [ -f "secrets/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export SECRETS_OPT="-var-file=secrets/${MATURITY}.tfvars"
+		echo "Found maturity-specific secrets: $$SECRETS_OPT"
+		echo "***************************************************************"
+	fi
+	if [ -f "variables/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export VARIABLES_OPT="-var-file=variables/${MATURITY}.tfvars"
+		echo "Found maturity-specific variables: $$VARIABLES_OPT"
+		echo "***************************************************************"
+	fi
+	terraform apply \
+		$$SECRETS_OPT \
+		$$VARIABLES_OPT \
+		-input=false \
+		-auto-approve \
+		-no-color
+
+# ---------------------------
+destroy-orca: orca-init
+	$(banner)
+	cd orca
+	if [ -f "secrets/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export SECRETS_OPT="-var-file=secrets/${MATURITY}.tfvars"
+		echo "Found maturity-specific secrets: $$SECRETS_OPT"
+		echo "***************************************************************"
+	fi
+	if [ -f "variables/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export VARIABLES_OPT="-var-file=variables/${MATURITY}.tfvars"
+		echo "Found maturity-specific variables: $$VARIABLES_OPT"
+		echo "***************************************************************"
+	fi
+	terraform destroy \
+		$$SECRETS_OPT \
+		$$VARIABLES_OPT \
+		-input=false \
+		-auto-approve \
+		-no-color
+
+# ---------------------------
+plan-orca: orca-init
+	$(banner)
+	cd orca
+	if [ -f "secrets/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export SECRETS_OPT="-var-file=secrets/${MATURITY}.tfvars"
+		echo "Found maturity-specific secrets: $$SECRETS_OPT"
+		echo "***************************************************************"
+	fi
+	if [ -f "variables/${MATURITY}.tfvars" ]
+	then
+		echo "***************************************************************"
+		export VARIABLES_OPT="-var-file=variables/${MATURITY}.tfvars"
+		echo "Found maturity-specific variables: $$VARIABLES_OPT"
+		echo "***************************************************************"
+	fi
+	terraform plan \
+		$$SECRETS_OPT \
+		$$VARIABLES_OPT \
+		-input=false \
+		-no-color
+
+
+
+
 # ---------------------------
 pcrs: workflows/providers/* workflows/collections/* workflows/rules/*
 	if [ -z ${cumulus_id_rsa+x} ];  then echo "Env Var \$cumulus_id_rsa is not set, using ~/.ssh/id_rsa"; fi

--- a/orca/data.tf
+++ b/orca/data.tf
@@ -1,0 +1,52 @@
+## --------------------------
+## Database configuration
+## --------------------------
+
+## TODO - Decide if it's valueable to allow for an alternate cluster to the rds module cluster
+## OBDAAC implementation makes it YAGNI
+data "aws_secretsmanager_secret" "rds_admin_credentials" {
+  arn =  data.terraform_remote_state.rds.outputs.admin_db_login_secret_arn
+}
+
+data "aws_secretsmanager_secret_version" "rds_admin_credentials" {
+  secret_id = data.aws_secretsmanager_secret.rds_admin_credentials.id
+}
+
+
+## --------------------------
+## AWS configuration
+## --------------------------
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+
+data "aws_subnets" "subnet_ids" {
+  filter {
+    name = "tag:Name"
+    values = ["Private application ${data.aws_region.current.name}a subnet",
+    "Private application ${data.aws_region.current.name}b subnet"]
+  }
+}
+
+data "aws_vpc" "application_vpcs" {
+  tags = {
+    Name = "Application VPC"
+  }
+}
+
+## --------------------------
+## Remote state configuration
+## --------------------------
+
+data "terraform_remote_state" "rds" {
+  backend   = "s3"
+  workspace = var.DEPLOY_NAME
+  config    = local.rds_remote_state_config
+}
+
+data "terraform_remote_state" "daac" {
+  backend   = "s3"
+  workspace = var.DEPLOY_NAME
+  config    = local.daac_remote_state_config
+}

--- a/orca/locals.tf
+++ b/orca/locals.tf
@@ -1,0 +1,23 @@
+locals {
+  default_tags = {
+    Deployment = local.prefix
+  }
+  ## TODO - These should probably be module outputs from Cirrus rather than convention
+  system_bucket = data.terraform_remote_state.daac.outputs.bucket_map.internal.name
+
+  prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
+  rds_remote_state_config = {
+    bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
+    key    = "rds/terraform.tfstate"
+    region = data.aws_region.current.name
+  }
+  daac_remote_state_config = {
+    bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
+    key    = "daac/terraform.tfstate"
+    region = data.aws_region.current.name
+  }
+  rds_admin_login = jsondecode(data.aws_secretsmanager_secret_version.rds_admin_credentials.secret_string)
+  permissions_boundary_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/NGAPShRoleBoundary"
+  daac_bucket_map = data.terraform_remote_state.daac.outputs.bucket_map
+  merged_bucket_map = merge(local.daac_bucket_map, { for n in var.orca_buckets : n => { name = n, type = "orca"} })
+}

--- a/orca/orca.tf
+++ b/orca/orca.tf
@@ -1,0 +1,59 @@
+module "orca" {
+  source = "https://github.com/nasa/cumulus-orca/releases/download/v8.1.0/cumulus-orca-terraform.zip"
+  ## --------------------------
+  ## Cumulus Variables
+  ## --------------------------
+  ## REQUIRED
+  aws_region               = data.aws_region.current.name
+  buckets                  = local.merged_bucket_map
+  lambda_subnet_ids        = data.aws_subnets.subnet_ids.ids
+  permissions_boundary_arn = local.permissions_boundary_arn
+  prefix                   = local.prefix
+  system_bucket            = local.system_bucket
+  vpc_id                   = data.aws_vpc.application_vpcs.id
+
+  ## OPTIONAL
+  tags        = local.default_tags
+
+  ## --------------------------
+  ## ORCA Variables
+  ## --------------------------
+  ## REQUIRED
+
+  db_admin_password        = local.rds_admin_login.password
+  db_admin_username        = local.rds_admin_login.username
+  db_host_endpoint         = local.rds_admin_login.host
+  db_user_password         = var.orca_db_user_password
+  dlq_subscription_email   = var.orca_dlq_subscription_email
+  orca_default_bucket      = var.orca_default_bucket
+  orca_reports_bucket_name = var.orca_reports_bucket
+  rds_security_group_id    = data.terraform_remote_state.rds.outputs.rds_security_group_id
+  s3_access_key            = var.orca_s3_access_key
+  s3_secret_key            = var.orca_s3_secret_key
+
+  ## OPTIONAL
+  default_multipart_chunksize_mb                         = var.default_multipart_chunksize_mb
+  metadata_queue_message_retention_time_seconds          = var.metadata_queue_message_retention_time_seconds
+  orca_default_recovery_type                             = var.orca_default_recovery_type
+  orca_default_storage_class                             = var.orca_default_storage_class
+  orca_delete_old_reconcile_jobs_frequency_cron          = var.orca_delete_old_reconcile_jobs_frequency_cron
+  orca_ingest_lambda_memory_size                         = var.orca_ingest_lambda_memory_size
+  orca_ingest_lambda_timeout                             = var.orca_ingest_lambda_timeout
+  orca_internal_reconciliation_expiration_days           = var.orca_internal_reconciliation_expiration_days
+  orca_reconciliation_lambda_memory_size                 = var.orca_reconciliation_lambda_memory_size
+  orca_reconciliation_lambda_timeout                     = var.orca_reconciliation_lambda_timeout
+  orca_recovery_buckets                                  = var.orca_recovery_buckets
+  orca_recovery_complete_filter_prefix                   = var.orca_recovery_complete_filter_prefix
+  orca_recovery_expiration_days                          = var.orca_recovery_expiration_days
+  orca_recovery_lambda_memory_size                       = var.orca_recovery_lambda_memory_size
+  orca_recovery_lambda_timeout                           = var.orca_recovery_lambda_timeout
+  orca_recovery_retry_limit                              = var.orca_recovery_retry_limit
+  orca_recovery_retry_interval                           = var.orca_recovery_retry_interval
+  orca_recovery_retry_backoff                            = var.orca_recovery_retry_backoff
+  s3_inventory_queue_message_retention_time_seconds      = var.s3_inventory_queue_message_retention_time_seconds
+  s3_report_frequency                                    = var.s3_report_frequency
+  sqs_delay_time_seconds                                 = var.sqs_delay_time_seconds
+  sqs_maximum_message_size                               = var.sqs_maximum_message_size
+  staged_recovery_queue_message_retention_time_seconds   = var.staged_recovery_queue_message_retention_time_seconds
+  status_update_queue_message_retention_time_seconds     = var.status_update_queue_message_retention_time_seconds
+}

--- a/orca/orca_cumulus_internal_s3_policy.tpl
+++ b/orca/orca_cumulus_internal_s3_policy.tpl
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${elb_account_id}:root"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::${prefix}-internal/${prefix}-lb-gql-a-logs/*"
+        }
+    ]
+}

--- a/orca/outputs.tf
+++ b/orca/outputs.tf
@@ -1,0 +1,7 @@
+output "merged_bucket_map" {
+    value = local.merged_bucket_map
+}
+
+output "orca_module" {
+    value = module.orca
+}

--- a/orca/policy.tf
+++ b/orca/policy.tf
@@ -1,0 +1,16 @@
+## Bucket policy required for Orca load balancer 
+## See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
+
+resource "aws_s3_bucket_policy" "load_balancer_log_access" {
+    bucket = local.system_bucket
+    policy = data.template_file.load_balancer_s3_policy.rendered
+}
+
+data "template_file" "load_balancer_s3_policy" {
+  template = file("${path.module}/orca_cumulus_internal_s3_policy.tpl")
+
+  vars = {
+    prefix = local.prefix
+    elb_account_id = var.elb_account_id 
+  }
+}

--- a/orca/secrets/example.tfvars
+++ b/orca/secrets/example.tfvars
@@ -1,0 +1,2 @@
+orca_db_user_password="<db password goes here>"
+orca_default_bucket="<default bucket goes here>"

--- a/orca/variables.tf
+++ b/orca/variables.tf
@@ -1,0 +1,185 @@
+## Required
+
+### Module
+
+variable "DEPLOY_NAME" {
+  type = string
+}
+
+### Orca
+
+variable "orca_db_user_password" {
+  description = "Password for RDS Orca database user authentication"
+  type        = string
+}
+
+variable "orca_dlq_subscription_email" {
+  type        = string
+  description = "The email to notify users when messages are received in dead letter SQS queue due to orca restore failure."
+  default = "test@email.com" ## TODO: Set this via secret and remove default
+}
+
+variable "orca_default_bucket" {
+  type        = string
+  description = "Default ORCA S3 Glacier bucket to use."
+}
+
+variable "orca_reports_bucket" {
+  type        = string
+  description = "ORCA Reports Bucket"
+}
+
+variable "orca_buckets" {
+  type = list(string)
+}
+
+## Optional
+
+### Module
+
+variable "MATURITY" {
+  type    = string
+  default = "dev"
+}
+
+variable "elb_account_id" {
+  type = string
+  default = "797873946194"
+}
+
+### Orca
+
+# See available orca docs at https://nasa.github.io/cumulus-orca/docs/developer/deployment-guide/deployment-with-cumulus#creating-cumulus-tforcatf
+
+variable "default_multipart_chunksize_mb" {
+  type        = number
+  default = 250
+}
+
+
+variable "metadata_queue_message_retention_time_seconds" {
+  type        = number
+  default = 777600
+}
+
+variable "orca_default_recovery_type" {
+  type        = string
+  default = "Standard"
+}
+
+variable "orca_default_storage_class" {
+  type        = string
+  default = "GLACIER"
+}
+
+variable "orca_delete_old_reconcile_jobs_frequency_cron" {
+  type        = string
+  default = "cron(0 0 ? * SUN *)"
+}
+
+variable "orca_ingest_lambda_memory_size" {
+  type        = number
+  default = 2240
+}
+
+variable "orca_ingest_lambda_timeout" {
+  type        = number
+  default = 600
+}
+
+variable "orca_internal_reconciliation_expiration_days" {
+  type        = number
+  default = 30
+}
+
+variable "orca_reconciliation_lambda_memory_size" {
+  type        = number
+  default = 128
+}
+
+variable "orca_reconciliation_lambda_timeout" {
+  type        = number
+  default = 720
+}
+
+variable "orca_recovery_buckets" {
+  type        = list(string)
+  default = []
+}
+
+variable "orca_recovery_complete_filter_prefix" {
+  type        = string
+  default = ""
+}
+
+variable "orca_recovery_expiration_days" {
+  type        = number
+  default = 5
+}
+
+variable "orca_recovery_lambda_memory_size" {
+  type        = number
+  default = 128
+}
+
+variable "orca_recovery_lambda_timeout" {
+  type        = number
+  default = 720
+}
+
+variable "orca_recovery_retry_limit" {
+  type        = number
+  default = 3
+}
+
+variable "orca_recovery_retry_interval" {
+  type        = number
+  default = 1
+}
+
+variable "orca_recovery_retry_backoff" {
+  type        = number
+  default = 2
+}
+
+variable "s3_inventory_queue_message_retention_time_seconds" {
+  type        = number
+  default = 432000
+}
+
+variable "s3_report_frequency" {
+  type        = string
+  default = "Daily"
+}
+
+variable "sqs_delay_time_seconds" {
+  type        = number
+  default = 0
+}
+
+variable "sqs_maximum_message_size" {
+  type        = number
+  default = 262144
+}
+
+variable "staged_recovery_queue_message_retention_time_seconds" {
+  type        = number
+  default = 432000
+}
+
+variable "status_update_queue_message_retention_time_seconds" {
+  type        = number
+  default = 777600
+}
+
+variable "orca_s3_access_key" {
+  type        = string
+  description = "Access key for communicating with Orca S3 buckets."
+  default = ""
+}
+
+variable "orca_s3_secret_key" {
+  type        = string
+  description = "Secret key for communicating with Orca S3 buckets."
+  default = ""
+}

--- a/orca/variables/example.tfvars
+++ b/orca/variables/example.tfvars
@@ -1,0 +1,3 @@
+orca_buckets = ["<orca_buckets_go_here>"]
+orca_default_bucket = "<default_bucket_goes_here>"
+orca_reports_bucket = "<reports_bucket_goes_here>"

--- a/orca/versions.tf
+++ b/orca/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 0.13"
+}
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  backend "s3" {}
+}
+
+provider "aws" {
+  ignore_tags {
+    key_prefixes = ["gsfc-ngap"]
+  }
+}

--- a/orca_recovery_workflow/data.tf
+++ b/orca_recovery_workflow/data.tf
@@ -1,0 +1,13 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "terraform_remote_state" "daac" {
+  backend   = "s3"
+  workspace = var.DEPLOY_NAME
+  config    = local.daac_remote_state_config
+}
+data "terraform_remote_state" "cumulus" {
+  backend   = "s3"
+  workspace = var.DEPLOY_NAME
+  config    = local.cumulus_remote_state_config
+}

--- a/orca_recovery_workflow/locals.tf
+++ b/orca_recovery_workflow/locals.tf
@@ -1,0 +1,19 @@
+locals {
+    default_tags = {
+        Deployment = local.prefix
+    }
+    prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
+    daac_remote_state_config = {
+        bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
+        key    = "daac/terraform.tfstate"
+        region = data.aws_region.current.name
+    }
+    cumulus_remote_state_config = {
+        bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
+        key    = "cumulus/terraform.tfstate"
+        region = data.aws_region.current.name
+    }
+    orca_recovery_adapter_task_arn = data.terraform_remote_state.cumulus.outputs.orca_recovery_adapter_task.task_arn
+    workflow_config = data.terraform_remote_state.cumulus.outputs.workflow_config
+    system_bucket = data.terraform_remote_state.daac.outputs.bucket_map.internal.name
+}

--- a/orca_recovery_workflow/orca_recovery_adapter_workflow.asl.json
+++ b/orca_recovery_workflow/orca_recovery_adapter_workflow.asl.json
@@ -1,0 +1,50 @@
+{
+    "Comment": "Orca Recovery Adapter",
+    "StartAt": "OrcaRecoveryAdapter",
+    "States": {
+      "OrcaRecoveryAdapter": {
+        "Parameters": {
+          "cma": {
+            "event.$": "$",
+            "task_config": {
+              "buckets": "{$.meta.buckets}",
+              "fileBucketMaps": "{$.meta.collection.files}",
+              "asyncOperationId": "{$.cumulus_meta.asyncOperationId}",
+              "s3MultipartChunksizeMb": "{$.meta.collection.meta.s3MultipartChunksizeMb}",
+              "excludedFileExtensions": "{$.meta.collection.meta.orca.excludedFileExtensions}"
+            }
+          }
+        },
+        "Type": "Task",
+        "Resource": "${orca_recovery_adapter_task}",
+        "Next": "WorkflowSucceeded",
+        "Catch": [
+          {
+            "ErrorEquals": [
+              "States.ALL"
+            ],
+            "Next": "WorkflowFailed",
+            "ResultPath": "$.exception"
+          }
+        ],
+        "Retry": [
+          {
+            "ErrorEquals": [
+              "States.ALL"
+            ],
+            "IntervalSeconds": 2,
+            "MaxAttempts": 3,
+            "BackoffRate": 2
+          }
+        ]
+      },
+      "WorkflowSucceeded": {
+        "Type": "Succeed"
+      },
+      "WorkflowFailed": {
+        "Cause": "Workflow failed",
+        "Type": "Fail"
+      }
+    }
+  }
+  

--- a/orca_recovery_workflow/recovery_workflow.tf
+++ b/orca_recovery_workflow/recovery_workflow.tf
@@ -1,0 +1,17 @@
+module "orca_recovery_adapter_workflow" {
+  source = "https://github.com/nasa/cumulus/releases/download/v17.0.0/terraform-aws-cumulus-workflow.zip"
+
+  prefix          = local.prefix
+  name            = "OrcaRecoveryAdapterWorkflow"
+  workflow_config = local.workflow_config
+  system_bucket   = local.system_bucket
+  tags            = local.default_tags
+
+  state_machine_definition = templatefile(
+    "${path.module}/orca_recovery_adapter_workflow.asl.json",
+    {
+      orca_recovery_adapter_task: local.orca_recovery_adapter_task_arn
+    }
+  )
+}
+

--- a/orca_recovery_workflow/variables.tf
+++ b/orca_recovery_workflow/variables.tf
@@ -1,0 +1,12 @@
+## Required
+
+variable "DEPLOY_NAME" {
+  type = string
+}
+
+## Optional
+
+variable "MATURITY" {
+  type    = string
+  default = "dev"
+}

--- a/orca_recovery_workflow/versions.tf
+++ b/orca_recovery_workflow/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 0.13"
+}
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  backend "s3" {}
+}
+
+provider "aws" {
+  ignore_tags {
+    key_prefixes = ["gsfc-ngap"]
+  }
+}


### PR DESCRIPTION
This PR adds two daac user modules: 

* `orca` -- this module deploys ORCA (https://nasa.github.io/cumulus-orca/docs/operator/restore-to-orca) using remote state information from the `rds` and `daac` modules for database/bucket configuration, and provides output to the `cumulus` module (dependent on https://github.com/asfadmin/CIRRUS-core/pull/168 being merged) when configured to use orca.    This allows for use of the Cumulus provided ORCA adapter lambda in workflows to archive data to ORCA. 

As this initial effort was in support of OBDAAC who are using the Cumulus default database module, the module is currently assuming use of the `rds` module.   Improving this to allow for additional database clusters is beyond the scope of that work, but this module could be improved to accommodate other configurations.   

* `orca_recovery_workflow` -- This module takes outputs from the `cumulus` and `orca` modules to build a default 'recovery' workflow using the recovery adapter lambda Cumulus Core provides.     

I'd be happy to discuss further, provide demonstrations of the deployed modules, etc, as needed.   Thanks for your consideration. 