### PR TITLE
Add CIRRUS versions to terraform outputs

### DIFF
--- a/daac/outputs.tf
+++ b/daac/outputs.tf
@@ -1,3 +1,11 @@
+output "cirrus_core_version" {
+  value = var.CIRRUS_CORE_VERSION
+}
+
+output "cirrus_daac_version" {
+  value = var.CIRRUS_DAAC_VERSION
+}
+
 output "cma_layer_arn" {
   value = aws_lambda_layer_version.cma_layer.arn
 }

--- a/daac/outputs.tf
+++ b/daac/outputs.tf
@@ -1,3 +1,11 @@
+output "bucket_map" {
+  value = local.bucket_map
+}
+
+output "bucket_map_key" {
+  value = ""
+}
+
 output "cirrus_core_version" {
   value = var.CIRRUS_CORE_VERSION
 }
@@ -8,14 +16,6 @@ output "cirrus_daac_version" {
 
 output "cma_layer_arn" {
   value = aws_lambda_layer_version.cma_layer.arn
-}
-
-output "bucket_map" {
-  value = local.bucket_map
-}
-
-output "bucket_map_key" {
-  value = ""
 }
 
 /* export bucket_map_key if defined so it can be used in the cumulus step

--- a/daac/variables.tf
+++ b/daac/variables.tf
@@ -1,3 +1,13 @@
+variable "CIRRUS_CORE_VERSION" {
+  type        = string
+  description = "The version of the CIRRUS-core repository. It is set in the CIRRUS-core Makefile and passed to the docker container."
+}
+
+variable "CIRRUS_DAAC_VERSION" {
+  type        = string
+  description = "The version of the CIRRUS-DAAC repository. It is set in the CIRRUS-core Makefile and passed to the docker container."
+}
+
 variable "DEPLOY_NAME" {
   type = string
 }

--- a/daac/variables.tf
+++ b/daac/variables.tf
@@ -21,9 +21,19 @@ variable "cma_version" {
   type = string
 }
 
-variable "standard_bucket_names" {
+variable "dashboard_cloudfront_oai_id" {
+  type    = string
+  default = null
+}
+
+variable "distribution_bucket_oais" {
+  type    = map(any)
+  default = {}
+}
+
+variable "partner_bucket_names" {
   type    = list(string)
-  default = ["private"]
+  default = []
 }
 
 variable "protected_bucket_names" {
@@ -36,21 +46,6 @@ variable "public_bucket_names" {
   default = ["public"]
 }
 
-variable "workflow_bucket_names" {
-  type    = list(string)
-  default = []
-}
-
-variable "partner_bucket_names" {
-  type    = list(string)
-  default = []
-}
-
-variable "distribution_bucket_oais" {
-  type    = map(any)
-  default = {}
-}
-
 variable "s3_replicator_target_bucket" {
   type    = string
   default = null
@@ -61,7 +56,12 @@ variable "s3_replicator_target_prefix" {
   default = null
 }
 
-variable "dashboard_cloudfront_oai_id" {
-  type    = string
-  default = null
+variable "standard_bucket_names" {
+  type    = list(string)
+  default = ["private"]
+}
+
+variable "workflow_bucket_names" {
+  type    = list(string)
+  default = []
 }

--- a/dashboard/outputs.tf
+++ b/dashboard/outputs.tf
@@ -1,0 +1,7 @@
+output "cirrus_core_version" {
+  value = var.CIRRUS_CORE_VERSION
+}
+
+output "cirrus_daac_version" {
+  value = var.CIRRUS_DAAC_VERSION
+}

--- a/dashboard/variables.tf
+++ b/dashboard/variables.tf
@@ -1,3 +1,13 @@
+variable "CIRRUS_CORE_VERSION" {
+  type        = string
+  description = "The version of the CIRRUS-core repository. It is set in the CIRRUS-core Makefile and passed to the docker container."
+}
+
+variable "CIRRUS_DAAC_VERSION" {
+  type        = string
+  description = "The version of the CIRRUS-DAAC repository. It is set in the CIRRUS-core Makefile and passed to the docker container."
+}
+
 variable "DEPLOY_NAME" {
   type = string
 }

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -1,3 +1,11 @@
+output "cirrus_core_version" {
+  value = var.CIRRUS_CORE_VERSION
+}
+
+output "cirrus_daac_version" {
+  value = var.CIRRUS_DAAC_VERSION
+}
+
 output "rds_security_group_id" {
   value = module.rds_cluster.security_group_id
 }

--- a/rds/outputs.tf
+++ b/rds/outputs.tf
@@ -1,3 +1,11 @@
+output "admin_db_login_secret_arn" {
+  value = module.rds_cluster.admin_db_login_secret_arn
+}
+
+output "admin_db_login_secret_version" {
+  value = module.rds_cluster.admin_db_login_secret_version
+}
+
 output "cirrus_core_version" {
   value = var.CIRRUS_CORE_VERSION
 }
@@ -6,20 +14,12 @@ output "cirrus_daac_version" {
   value = var.CIRRUS_DAAC_VERSION
 }
 
-output "rds_security_group_id" {
-  value = module.rds_cluster.security_group_id
-}
-
 output "rds_endpoint" {
   value = module.rds_cluster.rds_endpoint
 }
 
-output "admin_db_login_secret_arn" {
-  value = module.rds_cluster.admin_db_login_secret_arn
-}
-
-output "admin_db_login_secret_version" {
-  value = module.rds_cluster.admin_db_login_secret_version
+output "rds_security_group_id" {
+  value = module.rds_cluster.security_group_id
 }
 
 output "rds_user_access_secret_arn" {

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -1,3 +1,13 @@
+variable "CIRRUS_CORE_VERSION" {
+  type        = string
+  description = "The version of the CIRRUS-core repository. It is set in the CIRRUS-core Makefile and passed to the docker container."
+}
+
+variable "CIRRUS_DAAC_VERSION" {
+  type        = string
+  description = "The version of the CIRRUS-DAAC repository. It is set in the CIRRUS-core Makefile and passed to the docker container."
+}
+
 variable "DEPLOY_NAME" {
   type = string
 }

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -17,10 +17,16 @@ variable "MATURITY" {
   default = "dev"
 }
 
-variable "db_admin_username" {
-  description = "Username for RDS database authentication"
+variable "backup_retention_period" {
+  description = "Number of backup periods to retain"
+  type        = number
+  default     = 1
+}
+
+variable "backup_window" {
+  description = "Preferred database backup window (UTC)"
   type        = string
-  default     = "cumulus_admin"
+  default     = "07:00-09:00"
 }
 
 variable "db_admin_password" {
@@ -29,16 +35,16 @@ variable "db_admin_password" {
   default     = ""
 }
 
+variable "db_admin_username" {
+  description = "Username for RDS database authentication"
+  type        = string
+  default     = "cumulus_admin"
+}
+
 variable "deletion_protection" {
   description = "Flag to prevent terraform from making changes that delete the database in CI"
   type        = bool
   default     = true
-}
-
-variable "snapshot_identifier" {
-  description = "Optional database snapshot for restoration"
-  type        = string
-  default     = null
 }
 
 variable "engine_version" {
@@ -60,19 +66,14 @@ variable "provision_user_database" {
   default     = true
 }
 
+
 variable "rds_user_password" {
   type    = string
   default = ""
 }
 
-variable "backup_retention_period" {
-  description = "Number of backup periods to retain"
-  type        = number
-  default     = 1
-}
-
-variable "backup_window" {
-  description = "Preferred database backup window (UTC)"
+variable "snapshot_identifier" {
+  description = "Optional database snapshot for restoration"
   type        = string
-  default     = "07:00-09:00"
+  default     = null
 }

--- a/workflows/outputs.tf
+++ b/workflows/outputs.tf
@@ -1,0 +1,7 @@
+output "cirrus_core_version" {
+  value = var.CIRRUS_CORE_VERSION
+}
+
+output "cirrus_daac_version" {
+  value = var.CIRRUS_DAAC_VERSION
+}

--- a/workflows/variables.tf
+++ b/workflows/variables.tf
@@ -1,3 +1,13 @@
+variable "CIRRUS_CORE_VERSION" {
+  type        = string
+  description = "The version of the CIRRUS-core repository. It is set in the CIRRUS-core Makefile and passed to the docker container."
+}
+
+variable "CIRRUS_DAAC_VERSION" {
+  type        = string
+  description = "The version of the CIRRUS-DAAC repository. It is set in the CIRRUS-core Makefile and passed to the docker container."
+}
+
 variable "DEPLOY_NAME" {
   type    = string
   default = "daac"

--- a/workflows/variables.tf
+++ b/workflows/variables.tf
@@ -13,12 +13,12 @@ variable "DEPLOY_NAME" {
   default = "daac"
 }
 
-variable "MATURITY" {
-  type    = string
-  default = "dev"
-}
-
 variable "DIST_DIR" {
   type    = string
   default = "../dist"
+}
+
+variable "MATURITY" {
+  type    = string
+  default = "dev"
 }


### PR DESCRIPTION
This PR adds the CIRRUS-core and CIRRUS-DAAC versions to the `daac`, `dashboard`, `rds`, and `workflows` modules. It also puts the variables and outputs in alphabetical order. If the file contained screaming snake case and snake case, I put the screaming snake case in alphabetical order in its own section. 