### PR TITLE
Clean up various examples and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## unreleased
 * Snyk fixes for dev-requirements.txt
+* Add descriptions to daac variables
 
 ## v18.2.0.0
 * Upgrade to [Cumulus v18.2.0](https://github.com/nasa/cumulus/releases/tag/v18.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## unreleased
 * Snyk fixes for dev-requirements.txt
 * Add descriptions to daac variables
+* Update default CMA version to 2.0.3
 
 ## v18.2.0.0
 * Upgrade to [Cumulus v18.2.0](https://github.com/nasa/cumulus/releases/tag/v18.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Snyk fixes for dev-requirements.txt
 * Add descriptions to daac variables
 * Update default CMA version to 2.0.3
+* Update example workflow lambda to use python3.8
 
 ## v18.2.0.0
 * Upgrade to [Cumulus v18.2.0](https://github.com/nasa/cumulus/releases/tag/v18.2.0)

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ pcrs: workflows/providers/* workflows/collections/* workflows/rules/*
 
 # We could get more granular with the dependencies here, but using the
 # dashboard directory is probably fine since we aren't developing it.
-${DASHBOARD_DIR}/dist: cumulus-dashboard cumulus-init
+${DASHBOARD_DIR}/dist: ${DASHBOARD_DIR} cumulus-init
 	if [ "${MATURITY}" = "dev" ]; then
 		export SERVED_BY_CUMULUS_API=true
 	fi
@@ -238,7 +238,7 @@ ${DASHBOARD_DIR}/dist: cumulus-dashboard cumulus-init
 	@echo "LABELS='$$LABELS'"
 	@echo "AUTH_METHOD='$$AUTH_METHOD'"
 	@echo "APIROOT='$$APIROOT'"
-	npm install --no-optional --cache ../.npm
+	npm install --no-optional --cache $(DASHBOARD_DIR)/.npm
 	npm run build
 
 .PHONY: dashboard

--- a/daac/locals.tf
+++ b/daac/locals.tf
@@ -6,11 +6,11 @@ locals {
   }
 
   dar_yes_tags = {
-    DAR        = "YES"
+    DAR = "YES"
   }
 
   dar_no_tags = {
-    DAR        = "NO"
+    DAR = "NO"
   }
 
 
@@ -33,7 +33,12 @@ locals {
   }
 
   # creates a TEA style bucket map, is outputted via outputs.tf
-  bucket_map = merge(local.standard_bucket_map, local.internal_bucket_map,
-    local.protected_bucket_map, local.public_bucket_map,
-  local.workflow_bucket_map, local.partner_bucket_map)
+  bucket_map = merge(
+    local.standard_bucket_map,
+    local.internal_bucket_map,
+    local.protected_bucket_map,
+    local.public_bucket_map,
+    local.workflow_bucket_map,
+    local.partner_bucket_map
+  )
 }

--- a/daac/s3-replicator.tf
+++ b/daac/s3-replicator.tf
@@ -33,7 +33,7 @@ module "s3-replicator" {
   vpc_id               = data.aws_vpc.application_vpcs.id
   subnet_ids           = data.aws_subnets.subnet_ids.ids
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/NGAPShRoleBoundary"
-  tags                 = { Deployment = local.prefix }
+  tags                 = local.default_tags
   source_bucket        = "${local.prefix}-internal"
   source_prefix        = "${local.prefix}/ems-distribution/s3-server-access-logs"
   target_bucket        = local.replicator_target_bucket

--- a/daac/terraform.tfvars
+++ b/daac/terraform.tfvars
@@ -1,23 +1,17 @@
 cma_version = "v2.0.3"
 
-# default bucket lists are:
-# standard_bucket_names = ["private"]
-# protected_bucket_names = ["protected"]
-# public_bucket_names = ["public"]
-
-# if you want to overide the default standard, protected or public bucket lists
+# If you want to overide the default standard, protected or public bucket lists
 # you can do it here
-standard_bucket_names  = ["private"]
-protected_bucket_names = ["protected", "protected-1"]
-public_bucket_names    = ["public", "public-1"]
+# standard_bucket_names  = ["private"]
+# protected_bucket_names = ["protected"]
+# public_bucket_names    = ["public"]
 
-# example workflow bucket list
-workflow_bucket_names = [
-  "acme-landing",
-  "acme-products",
-  "acme-browse"
-]
+# Example workflow bucket list
+# workflow_bucket_names = [
+#   "acme-landing",
+#   "acme-products",
+#   "acme-browse",
+# ]
 
-# Example of buckets we need to access, but won't create.
-# These ARE NOT prefixed
-partner_bucket_names = ["partner-collab-s3-bucket"]
+# Example partner bucket list. These ARE NOT prefixed
+# partner_bucket_names = ["partner-collab-s3-bucket"]

--- a/daac/terraform.tfvars
+++ b/daac/terraform.tfvars
@@ -1,4 +1,4 @@
-cma_version = "v1.3.0"
+cma_version = "v2.0.3"
 
 # default bucket lists are:
 # standard_bucket_names = ["private"]

--- a/daac/variables.tf
+++ b/daac/variables.tf
@@ -18,50 +18,60 @@ variable "MATURITY" {
 }
 
 variable "cma_version" {
-  type = string
+  type        = string
+  description = "Cumulus Message Adapter release version from https://github.com/nasa/cumulus-message-adapter/releases."
 }
 
 variable "dashboard_cloudfront_oai_id" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
+  description = "CloudFront OAI ID to use for dashboard bucket policy."
 }
 
 variable "distribution_bucket_oais" {
-  type    = map(any)
-  default = {}
+  type        = map(string)
+  default     = {}
+  description = "A map of bucket names to CloudFront OAI IDs. The OAI IDs will be added to the bucket policy to allow data distribution via CloudFront for those buckets."
 }
 
 variable "partner_bucket_names" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
+  description = "List of buckets which we need access to but do not create. Include the full bucket name."
 }
 
 variable "protected_bucket_names" {
-  type    = list(string)
-  default = ["protected"]
+  type        = list(string)
+  default     = []
+  description = "List of 'protected' buckets to create. The stack prefix is automatically added to the bucket names."
 }
 
 variable "public_bucket_names" {
-  type    = list(string)
-  default = ["public"]
+  type        = list(string)
+  default     = []
+  description = "List of 'public' buckets to create. The stack prefix is automatically added to the bucket names."
 }
 
 variable "s3_replicator_target_bucket" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
+  description = "Bucket that the S3 replicator will write logs to."
 }
 
 variable "s3_replicator_target_prefix" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
+  description = "Prefix that the S3 replicator will write logs to in the target bucket."
 }
 
 variable "standard_bucket_names" {
-  type    = list(string)
-  default = ["private"]
+  type        = list(string)
+  default     = []
+  description = "List of 'standard' buckets to create. The stack prefix is automatically added to the bucket names."
 }
 
 variable "workflow_bucket_names" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
+  description = "List of 'workflow' buckets to create. The stack prefix is automatically added to the bucket names."
 }

--- a/workflows/main.tf
+++ b/workflows/main.tf
@@ -31,4 +31,5 @@ resource "aws_lambda_function" "nop_lambda" {
   source_code_hash = filebase64sha256("${var.DIST_DIR}/lambdas.zip")
 
   runtime = "python3.7"
+  tags    = local.default_tags
 }

--- a/workflows/main.tf
+++ b/workflows/main.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_layer_version" "lambda_dependencies" {
   layer_name       = "${local.prefix}-lambda_dependencies"
   source_code_hash = filebase64sha256("${var.DIST_DIR}/lambda_dependencies_layer.zip")
 
-  compatible_runtimes = ["python3.7"]
+  compatible_runtimes = ["python3.8"]
 }
 
 resource "aws_lambda_function" "nop_lambda" {
@@ -30,6 +30,6 @@ resource "aws_lambda_function" "nop_lambda" {
   timeout          = 10
   source_code_hash = filebase64sha256("${var.DIST_DIR}/lambdas.zip")
 
-  runtime = "python3.7"
+  runtime = "python3.8"
   tags    = local.default_tags
 }


### PR DESCRIPTION
I found that in our prod account we still have some of these `protected-1`, `public-1`, etc and `acme-*` buckets deployed even though we have no use for them. So I decided to rework the defaults here a little bit so that the examples are not deployed by default and you need to explicitly opt-in to having any public/private/protected buckets get deployed.

- Fix some formatting things
- Clean up the daac variables a bit
  - Add descriptions
  - Remove usage of `any` type
  - Default to empty bucket lists
- Update some version defaults
- Fix an issue with the Makefile when using a non-default dashboard repo name