### PR TITLE
Refactor bucket config to use a single map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## unreleased
 * Snyk fixes for dev-requirements.txt
+* Refactored bucket configuration variables to use a single map. You will need
+  to merge your `standard_bucket_names`, `protected_bucket_names`,
+  `public_bucket_names`, and `workflow_bucket_names` into the new combined
+  `bucket_config_base` variable and add maturity specific config to
+  `bucket_config`.
 * Add descriptions to daac variables
 * Update default CMA version to 2.0.3
 * Update example workflow lambda to use python3.8

--- a/daac/distribution_bucket_policy.tf
+++ b/daac/distribution_bucket_policy.tf
@@ -1,11 +1,11 @@
 data "aws_cloudfront_origin_access_identity" "distribution_cloudfront_oai" {
-  for_each = toset(values(var.distribution_bucket_oais))
+  for_each = toset(values(local.distribution_bucket_oais))
 
   id = each.key
 }
 
 data "aws_iam_policy_document" "distribution_bucket_policy_document" {
-  for_each = var.distribution_bucket_oais
+  for_each = local.distribution_bucket_oais
 
   statement {
     actions   = ["s3:GetObject"]
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "distribution_bucket_policy_document" {
 }
 
 resource "aws_s3_bucket_policy" "distribution_bucket_policy" {
-  for_each = var.distribution_bucket_oais
+  for_each = local.distribution_bucket_oais
 
   bucket = "${local.prefix}-${each.key}"
   policy = try(data.aws_iam_policy_document.distribution_bucket_policy_document[each.key].json, null)

--- a/daac/locals.tf
+++ b/daac/locals.tf
@@ -13,17 +13,36 @@ locals {
     DAR = "NO"
   }
 
+  # Merge the bucket_config with base
+  # First, merge any configs that would override the base
+  partial_bucket_config = {
+    for n, cfg in var.bucket_config_base : n => merge(cfg, lookup(var.bucket_config, n, cfg))
+  }
+  # Then combine the override map with the merged base to capture additions
+  bucket_config = merge(var.bucket_config, local.partial_bucket_config)
 
-  standard_bucket_names  = [for n in var.standard_bucket_names : "${local.prefix}-${n}"]
-  protected_bucket_names = [for n in var.protected_bucket_names : "${local.prefix}-${n}"]
-  public_bucket_names    = [for n in var.public_bucket_names : "${local.prefix}-${n}"]
-  workflow_bucket_names  = [for n in var.workflow_bucket_names : "${local.prefix}-${n}"]
+  # Bucket types. These lists should not overlap
+  standard_bucket_names  = [for n, cfg in local.bucket_config : "${local.prefix}-${n}" if cfg.type == "standard"]
+  protected_bucket_names = [for n, cfg in local.bucket_config : "${local.prefix}-${n}" if cfg.type == "protected"]
+  public_bucket_names    = [for n, cfg in local.bucket_config : "${local.prefix}-${n}" if cfg.type == "public"]
+  workflow_bucket_names  = [for n, cfg in local.bucket_config : "${local.prefix}-${n}" if cfg.type == "workflow"]
 
-  standard_bucket_map  = { for n in var.standard_bucket_names : n => { name = "${local.prefix}-${n}", type = n } }
-  protected_bucket_map = { for n in var.protected_bucket_names : n => { name = "${local.prefix}-${n}", type = "protected" } }
-  public_bucket_map    = { for n in var.public_bucket_names : n => { name = "${local.prefix}-${n}", type = "public" } }
-  workflow_bucket_map  = { for n in var.workflow_bucket_names : n => { name = "${local.prefix}-${n}", type = "workflow" } }
-  partner_bucket_map   = { for n in var.partner_bucket_names : n => { name = n, type = "partner" } }
+  # Bucket attributes. These will enable additional configuration on some bucket
+  # in one of the lists above.
+  distribution_bucket_oais = { for n, cfg in local.bucket_config : n => cfg.oai if cfg.oai != null }
+
+  base_bucket_map = {
+    for n, cfg in local.bucket_config : n => {
+      name = "${local.prefix}-${n}"
+      type = cfg.type == "standard" ? n : cfg.type
+    }
+  }
+  partner_bucket_map = {
+    for n in var.partner_bucket_names : n => {
+      name = n
+      type = "partner"
+    }
+  }
   internal_bucket_map = {
     internal = {
       name = "${local.prefix}-internal"
@@ -33,11 +52,8 @@ locals {
 
   # creates a TEA style bucket map, is outputted via outputs.tf
   bucket_map = merge(
-    local.standard_bucket_map,
+    local.base_bucket_map,
     local.internal_bucket_map,
-    local.protected_bucket_map,
-    local.public_bucket_map,
-    local.workflow_bucket_map,
-    local.partner_bucket_map
+    local.partner_bucket_map,
   )
 }

--- a/daac/terraform.tfvars
+++ b/daac/terraform.tfvars
@@ -1,17 +1,16 @@
 cma_version = "v2.0.3"
 
-# If you want to overide the default standard, protected or public bucket lists
-# you can do it here
-# standard_bucket_names  = ["private"]
-# protected_bucket_names = ["protected"]
-# public_bucket_names    = ["public"]
-
-# Example workflow bucket list
-# workflow_bucket_names = [
-#   "acme-landing",
-#   "acme-products",
-#   "acme-browse",
-# ]
+# Set up the maturity agnostic part of your bucket configuration here.
+# For Example:
+# bucket_config_base = {
+#   "private"   = { type = "standard" }
+#   "protected" = { type = "protected" }
+#   "public"    = { type = "public" }
+#   # Workflow bucket list
+#   "acme-browse"   = { type = "workflow" }
+#   "acme-landing"  = { type = "workflow" }
+#   "acme-products" = { type = "workflow" }
+# }
 
 # Example partner bucket list. These ARE NOT prefixed
 # partner_bucket_names = ["partner-collab-s3-bucket"]

--- a/daac/variables.tf
+++ b/daac/variables.tf
@@ -17,6 +17,26 @@ variable "MATURITY" {
   default = "dev"
 }
 
+variable "bucket_config" {
+  type = map(object({
+    type = string
+    oai  = optional(string)
+  }))
+  default     = {}
+  description = "Maturity specific overrides for the base bucket config."
+}
+
+# type = {"standard", "protected", "public", "workflow"}
+# oai - The OAI ID will be added to the bucket policy to allow data distribution via CloudFront for this bucket.
+variable "bucket_config_base" {
+  type = map(object({
+    type = string
+    oai  = optional(string)
+  }))
+  default     = {}
+  description = "Map of buckets to create. Each bucket has a config that can be used to set the bucket type and enable extra features on the bucket. Add new features here as necessary."
+}
+
 variable "cma_version" {
   type        = string
   description = "Cumulus Message Adapter release version from https://github.com/nasa/cumulus-message-adapter/releases."
@@ -28,28 +48,10 @@ variable "dashboard_cloudfront_oai_id" {
   description = "CloudFront OAI ID to use for dashboard bucket policy."
 }
 
-variable "distribution_bucket_oais" {
-  type        = map(string)
-  default     = {}
-  description = "A map of bucket names to CloudFront OAI IDs. The OAI IDs will be added to the bucket policy to allow data distribution via CloudFront for those buckets."
-}
-
 variable "partner_bucket_names" {
   type        = list(string)
   default     = []
   description = "List of buckets which we need access to but do not create. Include the full bucket name."
-}
-
-variable "protected_bucket_names" {
-  type        = list(string)
-  default     = []
-  description = "List of 'protected' buckets to create. The stack prefix is automatically added to the bucket names."
-}
-
-variable "public_bucket_names" {
-  type        = list(string)
-  default     = []
-  description = "List of 'public' buckets to create. The stack prefix is automatically added to the bucket names."
 }
 
 variable "s3_replicator_target_bucket" {
@@ -62,16 +64,4 @@ variable "s3_replicator_target_prefix" {
   type        = string
   default     = null
   description = "Prefix that the S3 replicator will write logs to in the target bucket."
-}
-
-variable "standard_bucket_names" {
-  type        = list(string)
-  default     = []
-  description = "List of 'standard' buckets to create. The stack prefix is automatically added to the bucket names."
-}
-
-variable "workflow_bucket_names" {
-  type        = list(string)
-  default     = []
-  description = "List of 'workflow' buckets to create. The stack prefix is automatically added to the bucket names."
 }

--- a/daac/variables/sbx.tfvars
+++ b/daac/variables/sbx.tfvars
@@ -1,6 +1,8 @@
-#workflow_bucket_names = []
-#standard_bucket_names = ["private", "dashboard"]
-#partner_bucket_names = ["non-prefixed-external-bucket"]
+# Set the maturity specific part of your bucket configuration here.
+# bucket_config = {
+#   "acme-browse"   = { oai = "ABCDEFG1234567" }
+#   "acme-products" = { oai = "ABCDEFG1234567" }
+# }
 
-#s3_replicator_target_bucket = "metrics target bucket name"
-#s3_replicator_target_prefix = "metrics target prefix name"
+# s3_replicator_target_bucket = "metrics target bucket name"
+# s3_replicator_target_prefix = "metrics target prefix name"


### PR DESCRIPTION
At ASF we've needed to add several additional bucket features such as infrequent access and different logging configurations to our buckets. Using the existing setup this requires adding a new bucket list for each feature and duplicating the bucket names that the feature should be applied to.

To simplify this I decided to rework how the buckets are configured in the daac variables. Instead of separate lists for each bucket type there is now a single map of bucket name to config options where you can enable additional features on a bucket by bucket basis.

For example (note the only additional feature implemented in this repo is the `oai` for buckets that distribute data via CloudFront):
```hcl
bucket_config_base = {
  "private"   = { type = "standard" }
  "protected" = { type = "protected" }
  "public"    = { type = "public" }
  # Workflow bucket list
  "acme-browse" = { 
    type = "workflow" 
    oai  = "ABCDEFG1234567"
  }
  "acme-landing" = { type = "workflow" }
  "acme-products" = { 
    type = "workflow" 
    oai  = "ABCDEFG1234567"
    ia   = true
  }
}
```

Migrating to this new layout will require CIRRUS users to consolidate their existing bucket lists into this new map format and implement any additional features via the bucket config by following the example of how `oai` is done.

Adding an optional features simply requires:
1. Adding a flag to the type definition in `variables.tf`
2. Adding a `local` to `locals.tf` to capture all buckets with the flag enabled
3. Creating the resources using a `for_each` using the `local` defined in 2.


### Side Quest
Since the `optional` syntax is new since terraform 1.3 I had to update tflint. This added some new lints that were failing on our code, so I had to fix a few additional things as well. I decided to break this out to https://github.com/asfadmin/CIRRUS-DAAC/pull/100 and will rebase this one once the other is merged.