### PR TITLE
Update tflint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,19 +27,19 @@ jobs:
     - uses: terraform-linters/setup-tflint@v1
       name: Setup TFLint
       with:
-        tflint_version: v0.21.0
+        tflint_version: v0.51.1
 
     - name: Show version
       run: tflint --version
 
     - name: TFLint - daac module
-      run:  tflint daac
+      run:  tflint --chdir=daac
 
     - name: TFLint - dashboard module
-      run:  tflint dashboard
+      run:  tflint --chdir=dashboard
 
     - name: TFLint - rds module
-      run:  tflint rds
+      run:  tflint --chdir=rds
 
     - name: TFLint - workflows module
-      run:  tflint workflows
+      run:  tflint --chdir=workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add descriptions to daac variables
 * Update default CMA version to 2.0.3
 * Update example workflow lambda to use python3.8
+* Update tflint to [v0.51.1](https://github.com/terraform-linters/tflint/releases/tag/v0.51.1)
 
 ## v18.2.0.0
 * Upgrade to [Cumulus v18.2.0](https://github.com/nasa/cumulus/releases/tag/v18.2.0)

--- a/daac/locals.tf
+++ b/daac/locals.tf
@@ -18,7 +18,6 @@ locals {
   protected_bucket_names = [for n in var.protected_bucket_names : "${local.prefix}-${n}"]
   public_bucket_names    = [for n in var.public_bucket_names : "${local.prefix}-${n}"]
   workflow_bucket_names  = [for n in var.workflow_bucket_names : "${local.prefix}-${n}"]
-  partner_bucket_names   = [for n in var.partner_bucket_names : n]
 
   standard_bucket_map  = { for n in var.standard_bucket_names : n => { name = "${local.prefix}-${n}", type = n } }
   protected_bucket_map = { for n in var.protected_bucket_names : n => { name = "${local.prefix}-${n}", type = "protected" } }

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -11,23 +11,24 @@ resource "random_string" "user_db_pass" {
 }
 
 module "rds_cluster" {
-  source                   = "https://github.com/nasa/cumulus/releases/download/v18.2.0/terraform-aws-cumulus-rds.zip"
-  db_admin_username        = var.db_admin_username
-  db_admin_password        = var.db_admin_password == "" ? random_string.admin_db_pass.result : var.db_admin_password
-  region                   = data.aws_region.current.name
-  vpc_id                   = data.aws_vpc.application_vpcs.id
-  subnets                  = data.aws_subnets.subnet_ids.ids
-  engine_version           = var.engine_version
-  enable_upgrade           = var.enable_upgrade
-  parameter_group_family   = var.parameter_group_family
-  deletion_protection      = var.deletion_protection
-  backup_retention_period  = var.backup_retention_period
-  backup_window            = var.backup_window
-  cluster_identifier       = local.cluster_identifier
-  tags                     = local.default_tags
-  snapshot_identifier      = var.snapshot_identifier
-  provision_user_database  = var.provision_user_database
-  prefix                   = local.prefix
-  permissions_boundary_arn = local.permissions_boundary_arn
-  rds_user_password        = var.rds_user_password == "" ? random_string.user_db_pass.result : var.rds_user_password
+  source                     = "https://github.com/nasa/cumulus/releases/download/v18.2.0/terraform-aws-cumulus-rds.zip"
+  db_admin_username          = var.db_admin_username
+  db_admin_password          = var.db_admin_password == "" ? random_string.admin_db_pass.result : var.db_admin_password
+  region                     = data.aws_region.current.name
+  vpc_id                     = data.aws_vpc.application_vpcs.id
+  subnets                    = data.aws_subnets.subnet_ids.ids
+  engine_version             = var.engine_version
+  enable_upgrade             = var.enable_upgrade
+  parameter_group_family     = var.parameter_group_family
+  parameter_group_family_v13 = var.parameter_group_family_v13
+  deletion_protection        = var.deletion_protection
+  backup_retention_period    = var.backup_retention_period
+  backup_window              = var.backup_window
+  cluster_identifier         = local.cluster_identifier
+  tags                       = local.default_tags
+  snapshot_identifier        = var.snapshot_identifier
+  provision_user_database    = var.provision_user_database
+  prefix                     = local.prefix
+  permissions_boundary_arn   = local.permissions_boundary_arn
+  rds_user_password          = var.rds_user_password == "" ? random_string.user_db_pass.result : var.rds_user_password
 }

--- a/rds/provider.tf
+++ b/rds/provider.tf
@@ -5,7 +5,8 @@ terraform {
       version = "~> 5.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.6"
     }
   }
   backend "s3" {}

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -47,6 +47,12 @@ variable "deletion_protection" {
   default     = true
 }
 
+variable "enable_upgrade" {
+  description = "Flag to enable use of updated parameter group for postgres v13"
+  type        = bool
+  default     = true
+}
+
 variable "engine_version" {
   description = "Postgres engine version for serverless cluster"
   type        = string
@@ -81,10 +87,4 @@ variable "snapshot_identifier" {
   description = "Optional database snapshot for restoration"
   type        = string
   default     = null
-}
-
-variable "enable_upgrade" {
-  description = "Flag to enable use of updated parameter group for postgres v13"
-  type        = bool
-  default     = true
 }


### PR DESCRIPTION
We were using an old version of tflint because we needed 0.13 support. Now that cumulus has upgraded to 1.5+ we can update tflint to the latest version.

This adds some additional lints that are failing on our code base:
```
3 issue(s) found:

Warning: [Fixable] local.partner_bucket_names is declared but not used (terraform_unused_declarations)

  on daac/locals.tf line 21:
  21:   partner_bucket_names   = [for n in var.partner_bucket_names : n]

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_unused_declarations.md

Warning: Missing version constraint for provider "random" in `required_providers` (terraform_required_providers)

  on rds/provider.tf line 7:
   7:     random = {
   8:       source = "hashicorp/random"
   9:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "parameter_group_family_v13" is declared but not used (terraform_unused_declarations)

  on rds/variables.tf line 62:
  62: variable "parameter_group_family_v13" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.7.0/docs/rules/terraform_unused_declarations.md
```

Those are fixed here.