### PR TITLE
Use aws provider level `default_tags` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 # CHANGELOG
 
+## Unreleased
+* Tag resources using the aws provider level `default_tags` configuration
+
 ## v18.3.1.0
 * Snyk fixes for dev-requirements.txt
 * Add descriptions to daac variables

--- a/cumulus/provider.tf
+++ b/cumulus/provider.tf
@@ -13,8 +13,7 @@ terraform {
       version = "~> 2.2.0"
     }
   }
-  backend "s3" {
-  }
+  backend "s3" {}
 }
 
 provider "aws" {

--- a/daac/dashboard.tf
+++ b/daac/dashboard.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "dashboard_bucket" {
     prevent_destroy = true
   }
 
-  tags = merge(local.default_tags, local.dar_yes_tags)
+  tags = local.dar_yes_tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "dashboard_encryption_configuration" {

--- a/daac/main.tf
+++ b/daac/main.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "standard-bucket" {
   lifecycle {
     prevent_destroy = true
   }
-  tags = merge(local.default_tags, local.dar_yes_tags)
+  tags = local.dar_yes_tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "standard_bucket_encryption_configuration" {
@@ -31,7 +31,7 @@ resource "aws_s3_bucket" "internal-bucket" {
   lifecycle {
     prevent_destroy = true
   }
-  tags = merge(local.default_tags, local.dar_yes_tags)
+  tags = local.dar_yes_tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "internal_bucket_encryption_configuration" {
@@ -65,7 +65,7 @@ resource "aws_s3_bucket" "protected-bucket" {
   lifecycle {
     prevent_destroy = true
   }
-  tags = merge(local.default_tags, local.dar_no_tags)
+  tags = local.dar_no_tags
 }
 
 resource "aws_s3_bucket_logging" "protected_bucket_logging" {
@@ -95,7 +95,7 @@ resource "aws_s3_bucket" "public-bucket" {
   lifecycle {
     prevent_destroy = true
   }
-  tags = merge(local.default_tags, local.dar_no_tags)
+  tags = local.dar_no_tags
 }
 
 resource "aws_s3_bucket_logging" "public_bucket_logging" {
@@ -124,7 +124,7 @@ resource "aws_s3_bucket" "workflow-bucket" {
   lifecycle {
     prevent_destroy = true
   }
-  tags = merge(local.default_tags, local.dar_yes_tags)
+  tags = local.dar_yes_tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "workflow_bucket_encryption_configuration" {
@@ -144,7 +144,7 @@ resource "aws_s3_bucket" "artifacts-bucket" {
   lifecycle {
     prevent_destroy = true
   }
-  tags = merge(local.default_tags, local.dar_yes_tags)
+  tags = local.dar_yes_tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "artifacts_bucket_encryption_configuration" {

--- a/daac/provider.tf
+++ b/daac/provider.tf
@@ -17,6 +17,9 @@ terraform {
 }
 
 provider "aws" {
+  default_tags {
+    tags = local.default_tags
+  }
   ignore_tags {
     key_prefixes = ["gsfc-ngap"]
   }

--- a/daac/s3-replicator.tf
+++ b/daac/s3-replicator.tf
@@ -33,7 +33,6 @@ module "s3-replicator" {
   vpc_id               = data.aws_vpc.application_vpcs.id
   subnet_ids           = data.aws_subnets.subnet_ids.ids
   permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/NGAPShRoleBoundary"
-  tags                 = local.default_tags
   source_bucket        = "${local.prefix}-internal"
   source_prefix        = "${local.prefix}/ems-distribution/s3-server-access-logs"
   target_bucket        = local.replicator_target_bucket

--- a/dashboard/locals.tf
+++ b/dashboard/locals.tf
@@ -1,3 +1,7 @@
 locals {
   prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
+
+  default_tags = {
+    Deployment = local.prefix
+  }
 }

--- a/dashboard/provider.tf
+++ b/dashboard/provider.tf
@@ -13,6 +13,9 @@ terraform {
 }
 
 provider "aws" {
+  default_tags {
+    tags = local.default_tags
+  }
   ignore_tags {
     key_prefixes = ["gsfc-ngap"]
   }

--- a/rds/locals.tf
+++ b/rds/locals.tf
@@ -2,7 +2,7 @@ locals {
   prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
 
   default_tags = {
-    Deployment = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
+    Deployment = local.prefix
   }
 
   cluster_identifier = "${local.prefix}-rds-cluster"

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -25,7 +25,6 @@ module "rds_cluster" {
   backup_retention_period    = var.backup_retention_period
   backup_window              = var.backup_window
   cluster_identifier         = local.cluster_identifier
-  tags                       = local.default_tags
   snapshot_identifier        = var.snapshot_identifier
   provision_user_database    = var.provision_user_database
   prefix                     = local.prefix

--- a/rds/provider.tf
+++ b/rds/provider.tf
@@ -13,6 +13,9 @@ terraform {
 }
 
 provider "aws" {
+  default_tags {
+    tags = local.default_tags
+  }
   ignore_tags {
     key_prefixes = ["gsfc-ngap"]
   }

--- a/workflows/locals.tf
+++ b/workflows/locals.tf
@@ -1,12 +1,12 @@
 locals {
   prefix        = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
-  system_bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-internal"
+  system_bucket = "${local.prefix}-internal"
   default_tags = {
-    Deployment = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
+    Deployment = local.prefix
   }
 
   cumulus_remote_state_config = {
-    bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
+    bucket = "${local.prefix}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
     key    = "cumulus/terraform.tfstate"
     region = data.aws_region.current.name
   }

--- a/workflows/main.tf
+++ b/workflows/main.tf
@@ -6,7 +6,6 @@ module "acme_workflow" {
   name            = "ACMEWorkflow"
   workflow_config = data.terraform_remote_state.cumulus.outputs.workflow_config
   system_bucket   = local.system_bucket
-  tags            = local.default_tags
 
   state_machine_definition = templatefile("./acme.json", {
     task_arn = aws_lambda_function.nop_lambda.arn
@@ -31,5 +30,4 @@ resource "aws_lambda_function" "nop_lambda" {
   source_code_hash = filebase64sha256("${var.DIST_DIR}/lambdas.zip")
 
   runtime = "python3.8"
-  tags    = local.default_tags
 }

--- a/workflows/provider.tf
+++ b/workflows/provider.tf
@@ -13,6 +13,9 @@ terraform {
 }
 
 provider "aws" {
+  default_tags {
+    tags = local.default_tags
+  }
   ignore_tags {
     key_prefixes = ["gsfc-ngap"]
   }


### PR DESCRIPTION
This will apply the deployment tag to all resources automatically without us needing to remember to add it every time. This functionality was added in `v3.38.0` so might not have been available when Cumulus/CIRRUS was originally started.

https://developer.hashicorp.com/terraform/tutorials/aws/aws-default-tags