### PR TITLE
Update Dockerfile to be for tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update default CMA version to 2.0.3
 * Update example workflow lambda to use python3.8
 * Update tflint to [v0.51.1](https://github.com/terraform-linters/tflint/releases/tag/v0.51.1)
+* Update Dockerfile to be used for tests only
 
 ## v18.2.0.0
 * Upgrade to [Cumulus v18.2.0](https://github.com/nasa/cumulus/releases/tag/v18.2.0)

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ clean:
 	find workflows -name __pycache__ -type d -delete
 
 # ---------------------------
-image: Dockerfile
-	docker build -f Dockerfile -t cirrus-daac .
+image: tests.Dockerfile
+	docker build -f tests.Dockerfile -t cirrus-daac .
 
 container-shell:
 	docker run -it --rm \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Cumulus.
 
 ## Development Setup
 
-You can run tests inside of a Docker container:
+You can run tests inside of a Docker container [defined](https://github.com/asfadmin/CIRRUS-core/blob/master/Dockerfile)
+in CIRRUS-core:
 
         $ make image
         $ make container-shell

--- a/tests.Dockerfile
+++ b/tests.Dockerfile
@@ -38,6 +38,9 @@ RUN \
         echo "user:x:${USER}:0:root:/:/bin/bash" >> /etc/passwd
 
 # Install Requirements
-COPY workflows/dev-requirements.txt /opt/app/requirements.txt
-WORKDIR /opt/app
+COPY workflows/dev-requirements.txt /dev-requirements.txt
+COPY workflows/requirements.txt /requirements.txt
 RUN python3 -m pip install -r requirements.txt
+RUN python3 -m pip install -r dev-requirements.txt
+
+WORKDIR /CIRRUS-DAAC

--- a/workflows/dev-requirements.txt
+++ b/workflows/dev-requirements.txt
@@ -1,10 +1,5 @@
 flake8~=3.7
-ipython~=8.10
-jedi~=0.15.0
-black~=24.3.0
 pytest~=5.3
 pytest-watch~=4.2
-awscli~=1.27.90
-boto3~=1.11
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/workflows/dev-requirements.txt
+++ b/workflows/dev-requirements.txt
@@ -1,5 +1,3 @@
 flake8~=3.7
 pytest~=5.3
 pytest-watch~=4.2
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
-rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Currently, [CIRRUS-core ](https://github.com/asfadmin/CIRRUS-core/blob/master/Dockerfile)and CIRRUS-DAAC have similar Dockerfiles. This updates CIRRUS-DAAC's Dockerfile to focus just on tests. This will make it more clear when to use the CIRRUS-DAAC or CIRRUS-core Dockerfile. It also aligns with the CIRRUS-DAAC README. 