### PR TITLE
Revert "PR-5950: Update Python to 3.10"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * Update default CMA version to 2.0.3
 * Update example workflow lambda to use python3.8
 * Update tflint to [v0.51.1](https://github.com/terraform-linters/tflint/releases/tag/v0.51.1)
-* Update to Python3.10
 * Update Dockerfile to be used for tests only
 
 ## v18.2.0.0

--- a/workflows/locals.tf
+++ b/workflows/locals.tf
@@ -10,6 +10,4 @@ locals {
     key    = "cumulus/terraform.tfstate"
     region = data.aws_region.current.name
   }
-
-  python_version = "python3.10"
 }

--- a/workflows/main.tf
+++ b/workflows/main.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_layer_version" "lambda_dependencies" {
   layer_name       = "${local.prefix}-lambda_dependencies"
   source_code_hash = filebase64sha256("${var.DIST_DIR}/lambda_dependencies_layer.zip")
 
-  compatible_runtimes = ["python3.10"]
+  compatible_runtimes = ["python3.8"]
 }
 
 resource "aws_lambda_function" "nop_lambda" {
@@ -30,6 +30,6 @@ resource "aws_lambda_function" "nop_lambda" {
   timeout          = 10
   source_code_hash = filebase64sha256("${var.DIST_DIR}/lambdas.zip")
 
-  runtime = local.python_version
+  runtime = "python3.8"
   tags    = local.default_tags
 }


### PR DESCRIPTION
Reverts asfadmin/CIRRUS-DAAC#106

Reverting till I fix the issue with the Python update in CIRRUS-core. While CIRRUS-DAAC's code ran, there were issues with more complex workflows. 