### PR TITLE
Update Lambda python version to 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 # CHANGELOG
 
+## Unreleased
+* Update Lambda runtime to Python3.9
+
 ## v18.3.1.0
 * Snyk fixes for dev-requirements.txt
 * Add descriptions to daac variables

--- a/workflows/locals.tf
+++ b/workflows/locals.tf
@@ -10,4 +10,6 @@ locals {
     key    = "cumulus/terraform.tfstate"
     region = data.aws_region.current.name
   }
+
+  python_version = "python3.9"
 }

--- a/workflows/main.tf
+++ b/workflows/main.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_layer_version" "lambda_dependencies" {
   layer_name       = "${local.prefix}-lambda_dependencies"
   source_code_hash = filebase64sha256("${var.DIST_DIR}/lambda_dependencies_layer.zip")
 
-  compatible_runtimes = ["python3.8"]
+  compatible_runtimes = [local.python_version]
 }
 
 resource "aws_lambda_function" "nop_lambda" {
@@ -30,6 +30,6 @@ resource "aws_lambda_function" "nop_lambda" {
   timeout          = 10
   source_code_hash = filebase64sha256("${var.DIST_DIR}/lambdas.zip")
 
-  runtime = "python3.8"
+  runtime = local.python_version
   tags    = local.default_tags
 }


### PR DESCRIPTION
After some investigation, the issue in this [PR](https://github.com/asfadmin/CIRRUS-DAAC/pull/106) was caused by an ASF repo that our ingest was using.