### PR TITLE
Pass tags to cumulus RDS module manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   `public_bucket_names`, and `workflow_bucket_names` into the new combined
   `bucket_config_base` variable and add maturity specific config to
   `bucket_config`.
+* Re-Add manual passing of tags to RDS cumulus module. [CUMULUS-3896](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3896)
 
 ## v18.3.3.1
 * Add `auto_pause` and `seconds_until_auto_pause` variables from Cumulus 18.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 # CHANGELOG
 
 ## Unreleased
+* Refactored bucket configuration variables to use a single map. You will need
+  to merge your `standard_bucket_names`, `protected_bucket_names`,
+  `public_bucket_names`, and `workflow_bucket_names` into the new combined
+  `bucket_config_base` variable and add maturity specific config to
+  `bucket_config`.
 
 ## v18.3.3.1
 * Add `auto_pause` and `seconds_until_auto_pause` variables from Cumulus 18.3.2
@@ -11,11 +16,6 @@
 * Upgrade to [Cumulus v18.3.3](https://github.com/nasa/cumulus/releases/tag/v18.3.3)
 * Update Lambda runtime to Python3.9
 * Tag resources using the aws provider level `default_tags` configuration
-* Refactored bucket configuration variables to use a single map. You will need
-  to merge your `standard_bucket_names`, `protected_bucket_names`,
-  `public_bucket_names`, and `workflow_bucket_names` into the new combined
-  `bucket_config_base` variable and add maturity specific config to
-  `bucket_config`.
 
 ## v18.3.1.0
 * Upgrade to [Cumulus v18.3.1](https://github.com/nasa/cumulus/releases/tag/v18.3.1)

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -33,4 +33,9 @@ module "rds_cluster" {
   prefix                     = local.prefix
   permissions_boundary_arn   = local.permissions_boundary_arn
   rds_user_password          = var.rds_user_password == "" ? random_string.user_db_pass.result : var.rds_user_password
+
+  # The RDS module defines a legacy provider configuration which preempts our
+  # configuration and stops the default_tags from being applied:
+  # https://bugs.earthdata.nasa.gov/browse/CUMULUS-3896
+  tags = local.default_tags
 }


### PR DESCRIPTION
The cumulus RDS module defines a legacy provider configuration which prevents our provider configuration from taking effect.

See https://bugs.earthdata.nasa.gov/browse/CUMULUS-3896