### PR TITLE
Add SNAPSHOT_IDENTIFIER variable to GitHub Actions CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,9 @@ on:
       DASHBOARD_API_ROOT:
         description: Override for the dashboard APIROOT variable
         default: ""
+      SNAPSHOT_IDENTIFIER:
+        description: Snapshot to use when upgrading the RDS to serverless v2
+        default: ""
       CORE_REPO:
         description: Repo that contains CIRRUS-core
         default: asfadmin/CIRRUS-core
@@ -91,6 +94,7 @@ jobs:
       MAKE_TARGET: ${{ github.event.inputs.MAKE_TARGET || 'workflows' }}
       API_ROOT: ${{ github.event.inputs.DASHBOARD_API_ROOT || '' }}
       MATURITY: ${{ github.event.inputs.MATURITY || 'sbx' }}
+      SNAPSHOT_IDENTIFIER: ${{ github.event.inputs.SNAPSHOT_IDENTIFIER || '' }}
       # GitHub Vars
       WORKSPACE: ${{ github.workspace }}
       CONTAINER_NAME_PREFIX: ${{ github.run_id }}
@@ -243,6 +247,7 @@ jobs:
                             --env TF_VAR_launchpad_token="${LAUNCHPAD_TOKEN}" \
                             --env TF_VAR_launchpad_passphrase="${LAUNCHPAD_PASSPHRASE}" \
                             --env TF_VAR_metrics_es_password="${METS_PASSWORD}" \
+                            --env TF_VAR_snapshot_identifier="$SNAPSHOT_IDENTIFIER" \
                             -v "$WORKSPACE/CIRRUS-core":/CIRRUS-core \
                             -v "$WORKSPACE/":/CIRRUS-DAAC \
                             -v /var/run/docker.sock:/var/run/docker.sock \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 # CHANGELOG
 
 ## Unreleased
+
+## v18.5.0.1
 * Add GitHub Actions pipeline for deploying to ASF's Sandbox account
+* Add SNAPSHOT_IDENTIFIER to GitHub Actions pipeline for the v18.5.0 upgrade
 
 ## v18.5.0.0
 * Upgrade to [Cumulus v18.5.0](https://github.com/nasa/cumulus/releases/tag/v18.5.0)
   * NOTE: This release may require manual execution per the v2 serverless RDS upgrade
   * RDS V2 migration [instructions](https://nasa.github.io/cumulus/docs/next/upgrade-notes/serverless-v2-upgrade/)
-* RDS module updates. 
-  * Removal of the following variables: 
+* RDS module updates.
+  * Removal of the following variables:
     * `enable_upgrade` upgrade flag that was used for Aurora v13 migration
     * `parameter_group_family` original parameter group family used for v13 migration
     * `auto_pause` No longer a variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 
 ## v18.5.0.0
 * Upgrade to [Cumulus v18.5.0](https://github.com/nasa/cumulus/releases/tag/v18.5.0)
-  * NOTE: This release may require manual execution per the v2 serverless RDS upgrade
+  * NOTE: This release may require manual execution per the v2 serverless RDS
+  upgrade. You must also update your `cumulus_rds_db_cluster` secret to include `"rejectUnauthorized": false` BEFORE applying the terraform changes otherwise
+  the provision-database lambda will fail to connect to the new RDS.
   * RDS V2 migration [instructions](https://nasa.github.io/cumulus/docs/next/upgrade-notes/serverless-v2-upgrade/)
 * RDS module updates.
   * Removal of the following variables:


### PR DESCRIPTION
Updating the secret like this works:
```terraform
data "aws_secretsmanager_secret_version" "rds_login" {
  secret_id  = module.rds_cluster.admin_db_login_secret_arn
  version_id = module.rds_cluster.admin_db_login_secret_version
}

resource "aws_secretsmanager_secret_version" "rds_login_override" {
  secret_id = module.rds_cluster.admin_db_login_secret_arn
  secret_string = jsonencode(
    merge(
      jsondecode(data.aws_secretsmanager_secret_version.rds_login.secret_string),
      {
        disableSSL         = var.disableSSL
        rejectUnauthorized = var.rejectUnauthorized
      },
    )
  )
}
```

However, the rds module is a 'legacy' module due to it including a `provider` block, so terraform doesn't allow us to use a `depends_on` with it, which would be required since we have to update the secret BEFORE deploying the module.

I added a note in the changelog that mentions the required manual secret update before deploying.