### PR TITLE
Add variables to `rds` module for tweaking resource allocation settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 * Remove `figlet` and `banner` from the `Making ...` banner.
 * Remove unused providers `null` and `archive` and bump pinned version of `null`
 in `daac` module.
+* Add variables to `rds` module:
+  * `cluster_instance_count`
+  * `lambda_memory_sizes`
+  * `lambda_timeouts`
+  * `max_capacity`
+  * `min_capacity`
 
 ## v20.0.0.0
 * Upgrade to [Cumulus v20.0.0](https://github.com/nasa/cumulus/releases/tag/v20.0.0)

--- a/rds/main.tf
+++ b/rds/main.tf
@@ -16,11 +16,16 @@ module "rds_cluster" {
   backup_retention_period    = var.backup_retention_period
   backup_window              = var.backup_window
   cluster_identifier         = local.cluster_identifier
+  cluster_instance_count     = var.cluster_instance_count
   db_admin_password          = var.db_admin_password == "" ? random_string.admin_db_pass.result : var.db_admin_password
   db_admin_username          = var.db_admin_username
   deletion_protection        = var.deletion_protection
   disableSSL                 = var.disableSSL
   engine_version             = var.engine_version
+  lambda_memory_sizes        = var.lambda_memory_sizes
+  lambda_timeouts            = var.lambda_timeouts
+  max_capacity               = var.max_capacity
+  min_capacity               = var.min_capacity
   parameter_group_family_v13 = var.parameter_group_family_v13
   permissions_boundary_arn   = local.permissions_boundary_arn
   prefix                     = local.prefix

--- a/rds/variables.tf
+++ b/rds/variables.tf
@@ -30,6 +30,12 @@ variable "backup_window" {
   default     = "07:00-09:00"
 }
 
+variable "cluster_instance_count" {
+  description = "Number of instances to create inside of the cluster"
+  type        = number
+  default     = 1
+}
+
 variable "db_admin_password" {
   description = "Password for RDS database authentication"
   type        = string
@@ -58,6 +64,28 @@ variable "engine_version" {
   description = "Postgres engine version for serverless cluster"
   type        = string
   default     = "13.12"
+}
+
+variable "lambda_memory_sizes" {
+  description = "Configurable map of memory sizes for lambdas"
+  type        = map(number)
+  default     = {}
+}
+
+variable "lambda_timeouts" {
+  description = "Configurable map of timeouts for lambdas"
+  type        = map(number)
+  default     = {}
+}
+
+variable "max_capacity" {
+  type    = number
+  default = 4
+}
+
+variable "min_capacity" {
+  type    = number
+  default = 2
 }
 
 variable "parameter_group_family_v13" {


### PR DESCRIPTION
These variables are needed for adjusting the available ACUs on the database as well as tweaking other capacity related settings.