### PR TITLE
PR-6337 Update default dashboard ref to minimum required version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ on:
         default: nasa/cumulus-dashboard
       DASHBOARD_REF:
         description: The cumulus-dashboard git ref to checkout
-        default: v12.2.0
+        default: v13.0.0
       DASHBOARD_API_ROOT:
         description: Override for the dashboard APIROOT variable
         default: ""

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,19 +15,19 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       name: Checkout source code
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       name: Cache plugin dir
       with:
         path: ~/.tflint.d/plugins
         key: ${{ matrix.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
 
-    - uses: terraform-linters/setup-tflint@v1
+    - uses: terraform-linters/setup-tflint@v4
       name: Setup TFLint
       with:
-        tflint_version: v0.51.1
+        tflint_version: v0.55.1
 
     - name: Show version
       run: tflint --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 # CHANGELOG
 
 ## Unreleased
+* Bump dashboard version to minimum required 13.0.0 in deploy.yml
 
 ## v20.0.1.0
 * Upgrade to [Cumulus v20.0.1](https://github.com/nasa/cumulus/releases/tag/v20.0.1)


### PR DESCRIPTION
Cumulus v20 requires dashboard v13.

There is a bug in version 13.0.0 where the Dockerfile command used to build the dashboard running `/bin/build_dashboard_via_docker.sh` does not install the dependencies successfully. This was fixed in https://github.com/nasa/cumulus-dashboard/pull/1174 but has not yet been released.