### PR TITLE
Lower RDS min_capacity to smallest allowed value in sandbox

### DIFF
--- a/rds/variables/sbx.tfvars
+++ b/rds/variables/sbx.tfvars
@@ -2,3 +2,6 @@
 # to false
 deletion_protection     = true
 provision_user_database = true
+
+# Set min_capacity to the lowest possible value in sandbox to lower idle cost.
+min_capacity = 0.5


### PR DESCRIPTION
Sandbox accounts may have a lot of stacks that are largely idle. This should allow the database to scale down when not in use. 

Note that as of engine version `13.15` the minimum becomes `0`, however the default engine version pinned by cumulus is `13.12`. I'm not sure if there are any risks associated with upgrading that, so I'm leaving it at the default for now.

Deployment to `daac-cumulus-sbx` succeeded.